### PR TITLE
Add default topic since topic may be empty from import (e.g. via api)

### DIFF
--- a/components/book/edit/BookTopicsChips.tsx
+++ b/components/book/edit/BookTopicsChips.tsx
@@ -15,7 +15,7 @@ type BookTopicsChipsProps = {
 };
 
 const parseTopics = (combined: string) => {
-  const parsedTopics = combined.split(";").filter((t: string) => t.length > 0);
+  const parsedTopics = (combined != null ? combined : ";").split(";").filter((t: string) => t.length > 0);
   return parsedTopics;
 };
 


### PR DESCRIPTION
If you add a book without a topic, the old code throws an error. Add default / empty value.