### PR TITLE
On enter in search bars, don't reload the whole page

### DIFF
--- a/components/book/BookSearchBar.tsx
+++ b/components/book/BookSearchBar.tsx
@@ -46,6 +46,9 @@ export default function BookSearchBar({
       <Grid>
         <Paper
           component="form"
+          onSubmit={(e) => {
+            e.preventDefault(); // Kein reload der Seite
+          }}
           sx={{
             p: "2px 4px",
             display: "flex",

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -204,6 +204,9 @@ export default function Users({ users, books, rentals }: UsersPropsType) {
           <Grid>
             <Paper
               component="form"
+              onSubmit={(e) => {
+                e.preventDefault(); // Kein reload der Seite
+              }}
               sx={{
                 p: "2px 4px",
                 display: "flex",


### PR DESCRIPTION
Aktuell lädt Enter in der Suchleiste für Bücher oder Nutzer die Seite neu. Scannen mit Ausweisen / Bücherlabels funktioniert daher nicht.