### PR TITLE
Book location field with autocomplete combobox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+OpenLibry is a school library management system built with Next.js (Pages Router), SQLite via Prisma, and NextAuth. It supports book rental management, barcode scanning, cover image fetching, and PDF/Excel report generation for small school libraries.
+
+## Commands
+
+```bash
+# Development
+npm run dev           # Start dev server with Turbopack
+npm run build         # Production build
+npm run lint          # Run ESLint
+
+# E2E tests (Cypress)
+npm run cypress       # Open Cypress UI
+npm run cypress:headless   # Run headless
+npm run test:e2e      # Start test server + run Cypress headless (uses .env.test.local)
+npm run test:e2e:ui   # Start test server + open Cypress UI
+
+# Database
+npx prisma migrate dev     # Apply migrations in development
+npx prisma db push         # Push schema changes without migration
+npx prisma generate        # Regenerate Prisma client
+npx prisma studio          # Open Prisma Studio GUI
+```
+
+## Architecture
+
+### Layer Structure
+
+- **`pages/`** — Next.js pages and API routes (Pages Router)
+- **`entities/`** — TypeScript types (`BookType`, `UserType`, etc.), Prisma DB access functions, and `db.ts` (Prisma singleton)
+- **`lib/`** — Shared utilities: i18n, logging, config, ISBN lookup services, date utils, label generation
+- **`components/`** — React components organized by domain (`book/`, `rental/`, `user/`, `layout/`, `labels/`, `reports/`, `ui/`)
+- **`prisma/`** — Schema and migrations; test DB at `prisma/database/automated-test-db.db`
+
+### Data Model
+
+Four Prisma models (SQLite):
+- **`User`** — Library patrons (students), linked to rented books
+- **`Book`** — Books with rental state (`rentalStatus`: `"available"` | `"rented"`, `dueDate`, `renewalCount`, `userId`)
+- **`LoginUser`** — Staff credentials for NextAuth login
+- **`Audit`** — Event log for business operations
+
+### Key Patterns
+
+**Database access** — Always import the Prisma singleton from `@/entities/db` and pass it into entity functions:
+```ts
+import { prisma } from "@/entities/db";
+import { getAllBooks } from "@/entities/book";
+const books = await getAllBooks(prisma);
+```
+
+**i18n** — Locale is fixed at build time via `NEXT_PUBLIC_OPENLIBRY_LOCALE`. Use the `t()` function everywhere (client and server):
+```ts
+import { t } from "@/lib/i18n";
+t("home.chooseSection")
+t("greeting.hello", { name: "Ada" })  // supports {placeholder} interpolation
+```
+Missing keys fall back to German, then to the raw key string.
+
+**Logging** — Use structured pino loggers from `@/lib/logger`, always including a `LogEvents` enum value:
+```ts
+import { businessLogger, errorLogger } from "@/lib/logger";
+import { LogEvents } from "@/lib/logEvents";
+businessLogger.info({ event: LogEvents.BOOK_CREATED, bookId: result.id }, "Book created");
+errorLogger.error({ event: LogEvents.API_ERROR, error: err.message }, "...");
+```
+
+**Configuration** — Runtime config is read from env vars. Business logic (rental durations, max extensions) comes from `lib/config/rentalConfig.ts` which reads `RENTAL_DURATION_DAYS`, `EXTENSION_DURATION_DAYS`, `MAX_EXTENSIONS`.
+
+### ISBN Lookup
+
+`/api/book/FillBookByIsbn` tries multiple services in cascade order: DNB SRU → Google Books → Open Library → ISBNSearch.org → DNB scraping. Services are defined in `lib/isbn-services/` and implement the `IsbnLookupService` interface.
+
+### Authentication
+
+NextAuth with `CredentialsProvider`. Passwords are stored hashed via `lib/utils/hashPassword.ts`. Auth can be disabled entirely via `AUTH_ENABLED=false` (development only). Session strategy is JWT with configurable timeout (`LOGIN_SESSION_TIMEOUT` env var, seconds).
+
+### E2E Testing
+
+Cypress uses a **separate test database** at `prisma/database/automated-test-db.db`, separate from the development DB. The `cypress.config.ts` registers custom tasks (`seedRentalData`, `resetDatabase`, `cleanupDatabase`) that operate on this test DB directly. Tests rely on `.env.test.local` for configuration. The fixture file `cypress/fixtures/automated-test-db-init.db` is the clean baseline that gets copied on reset.
+
+## Environment Setup
+
+Copy `.env_example` to `.env` and configure at minimum:
+- `DATABASE_URL` — SQLite file path (default: `file:./database/dev.db`)
+- `NEXTAUTH_SECRET` — random string for session encryption
+- `COVERIMAGE_FILESTORAGE_PATH` — directory for uploaded book cover images
+- `AUTH_ENABLED=false` — set during initial bootstrap to skip login
+
+For E2E tests, create `.env.test.local` pointing to the test database:
+```
+DATABASE_URL=file:./prisma/database/automated-test-db.db
+AUTH_ENABLED=false
+```

--- a/components/batch-scan/BatchScanEntryCard.tsx
+++ b/components/batch-scan/BatchScanEntryCard.tsx
@@ -10,6 +10,7 @@ import {
 import { BookType } from "@/entities/BookType";
 import { AlertTriangle, Edit, Image, RefreshCw, Trash2 } from "lucide-react";
 
+import LocationCombobox from "@/components/book/edit/LocationCombobox";
 import { CoverThumbnail } from "./CoverThumbnail";
 import { EditField } from "./EditField";
 import { InlineChipRow } from "./InlineChipRow";
@@ -274,6 +275,10 @@ export function BatchScanEntryCard({
                   label="Schlagwörter"
                   value={entry.bookData.topics || ""}
                   onChange={(v) => onUpdateBookData(entry.id, "topics", v)}
+                />
+                <LocationCombobox
+                  value={entry.bookData.location ?? ""}
+                  onChange={(v) => onUpdateBookData(entry.id, "location", v)}
                 />
                 <EditField
                   label="Seiten"

--- a/components/batch-scan/InlineChipRow.tsx
+++ b/components/batch-scan/InlineChipRow.tsx
@@ -1,4 +1,5 @@
 import { BookType } from "@/entities/BookType";
+import { MapPin } from "lucide-react";
 import { InlineChipField } from "./InlineChipField";
 import { ScannedEntry } from "./types";
 
@@ -19,6 +20,12 @@ export function InlineChipRow({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-1.5 mt-2.5 pt-2.5 border-t border-dashed border-gray-100">
+      {entry.bookData.location && (
+        <span className="inline-flex items-center gap-1 rounded-md border border-primary/25 bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+          <MapPin className="size-3 shrink-0" />
+          {entry.bookData.location}
+        </span>
+      )}
       <InlineChipField
         label="Schlagwörter"
         value={entry.bookData.topics || ""}

--- a/components/book/BookEditForm.tsx
+++ b/components/book/BookEditForm.tsx
@@ -637,6 +637,14 @@ export default function BookEditForm({
                 book={book}
               />
             </div>
+            <div>
+              <BookField
+                fieldType="location"
+                editable={editable}
+                setBookData={setBookData}
+                book={book}
+              />
+            </div>
           </div>
         </div>
 

--- a/components/book/BookEditForm.tsx
+++ b/components/book/BookEditForm.tsx
@@ -20,6 +20,7 @@ import BookSelect, {
   rentalStatusOptions,
 } from "./edit/BookSelect";
 import BookTopicsChips from "./edit/BookTopicsChips";
+import LocationCombobox from "./edit/LocationCombobox";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -531,15 +532,11 @@ export default function BookEditForm({
             {t("bookEditForm.sectionRentalStatus")}
           </SectionDivider>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 mb-3">
-            <div className="sm:col-span-2">
-              <BookField
-                fieldType="location"
-                editable={editable}
-                setBookData={setBookData}
-                book={book}
-              />
-            </div>
+          <div className="mb-3">
+            <LocationCombobox
+              value={book.location ?? ""}
+              onChange={(v) => setBookData({ ...book, location: v })}
+            />
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">

--- a/components/book/BookEditForm.tsx
+++ b/components/book/BookEditForm.tsx
@@ -531,6 +531,17 @@ export default function BookEditForm({
             {t("bookEditForm.sectionRentalStatus")}
           </SectionDivider>
 
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 mb-3">
+            <div className="sm:col-span-2">
+              <BookField
+                fieldType="location"
+                editable={editable}
+                setBookData={setBookData}
+                book={book}
+              />
+            </div>
+          </div>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
             <div>
               <BookSelect
@@ -632,14 +643,6 @@ export default function BookEditForm({
             <div>
               <BookField
                 fieldType="supplierComment"
-                editable={editable}
-                setBookData={setBookData}
-                book={book}
-              />
-            </div>
-            <div>
-              <BookField
-                fieldType="location"
                 editable={editable}
                 setBookData={setBookData}
                 book={book}

--- a/components/book/BookSummaryCard.tsx
+++ b/components/book/BookSummaryCard.tsx
@@ -239,6 +239,17 @@ function BookSummaryCard({
             {book.author}
           </p>
 
+          {/* Location */}
+          {book.location && (
+            <span
+              className="self-start px-1.5 py-0.5 rounded bg-black/40 backdrop-blur-sm
+                         text-[0.6rem] font-medium text-white/90 truncate max-w-full"
+              title={book.location}
+            >
+              {book.location}
+            </span>
+          )}
+
           {/* Topics */}
           <TopicChips topics={topics} onTopicClick={onTopicClick} />
 

--- a/components/book/edit/LocationCombobox.tsx
+++ b/components/book/edit/LocationCombobox.tsx
@@ -26,22 +26,20 @@ export default function LocationCombobox({
   useEffect(() => {
     fetch("/api/book/locations")
       .then((r) => r.json())
-      .then((data: LocationEntry[]) => {
-        setAllLocations(data);
-        // If the current value already matches an existing location on load, lock it
-        if (
-          value.trim() &&
-          data.some(
-            (l: LocationEntry) =>
-              l.location.toLowerCase() === value.trim().toLowerCase(),
-          )
-        ) {
-          setLocked(true);
-        }
-      })
+      .then((data: LocationEntry[]) => setAllLocations(data))
       .catch(() => {});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Sync locked state whenever value or known locations change
+  useEffect(() => {
+    if (!allLocations.length) return;
+    const isKnown =
+      value.trim() !== "" &&
+      allLocations.some(
+        (l) => l.location.toLowerCase() === value.trim().toLowerCase(),
+      );
+    setLocked(isKnown);
+  }, [value, allLocations]);
 
   const filtered = value.trim()
     ? allLocations.filter((l) =>

--- a/components/book/edit/LocationCombobox.tsx
+++ b/components/book/edit/LocationCombobox.tsx
@@ -1,7 +1,7 @@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { LocationEntry } from "@/pages/api/book/locations";
-import { MapPin } from "lucide-react";
+import { MapPin, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 interface LocationComboboxProps {
@@ -19,13 +19,28 @@ export default function LocationCombobox({
 }: LocationComboboxProps) {
   const [allLocations, setAllLocations] = useState<LocationEntry[]>([]);
   const [open, setOpen] = useState(false);
+  const [locked, setLocked] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     fetch("/api/book/locations")
       .then((r) => r.json())
-      .then((data: LocationEntry[]) => setAllLocations(data))
+      .then((data: LocationEntry[]) => {
+        setAllLocations(data);
+        // If the current value already matches an existing location on load, lock it
+        if (
+          value.trim() &&
+          data.some(
+            (l: LocationEntry) =>
+              l.location.toLowerCase() === value.trim().toLowerCase(),
+          )
+        ) {
+          setLocked(true);
+        }
+      })
       .catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const filtered = value.trim()
@@ -39,13 +54,24 @@ export default function LocationCombobox({
   );
 
   const hint =
-    value.trim() === ""
+    locked || value.trim() === ""
       ? null
       : exactMatch
-        ? `Vorhandener Standort · ${exactMatch.count} ${exactMatch.count === 1 ? "Buch" : "Bücher"}`
+        ? null // locked state handles this case
         : `Neuer Standort wird erstellt: „${value.trim()}"`;
 
-  const hintColor = exactMatch ? "text-success" : "text-warning";
+  const handleSelect = (loc: LocationEntry) => {
+    onChange(loc.location);
+    setLocked(true);
+    setOpen(false);
+  };
+
+  const handleUnlock = () => {
+    onChange("");
+    setLocked(false);
+    setOpen(false);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
 
   // Close on outside click
   useEffect(() => {
@@ -65,56 +91,80 @@ export default function LocationCombobox({
     <div ref={containerRef} className="relative flex flex-col gap-1.5">
       <Label className="text-xs text-muted-foreground">{label}</Label>
 
-      <div className="relative">
-        <MapPin className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
-        <Input
-          value={value}
-          autoFocus={autoFocus}
-          placeholder="z. B. Regal B-03"
-          className="pl-8"
-          onChange={(e) => {
-            onChange(e.target.value);
-            setOpen(true);
-          }}
-          onFocus={() => setOpen(true)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") setOpen(false);
-          }}
-        />
-      </div>
-
-      {/* Hint */}
-      {hint && (
-        <p className={`text-xs ${hintColor} leading-tight`}>{hint}</p>
-      )}
-
-      {/* Dropdown */}
-      {open && filtered.length > 0 && (
-        <ul
-          className="absolute z-50 top-full mt-1 w-full rounded-md border border-border
-                     bg-popover shadow-md overflow-hidden"
-          role="listbox"
-        >
-          {filtered.map((loc) => (
-            <li
-              key={loc.location}
-              role="option"
-              aria-selected={loc.location === value}
-              className="flex items-center justify-between px-3 py-2 text-sm
-                         cursor-pointer hover:bg-muted select-none"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                onChange(loc.location);
-                setOpen(false);
+      {locked ? (
+        /* ── Locked tag ── */
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md
+                       bg-primary/10 border border-primary/25 text-sm font-medium text-primary"
+          >
+            <MapPin className="h-3.5 w-3.5 shrink-0" />
+            {value}
+          </span>
+          <button
+            type="button"
+            onClick={handleUnlock}
+            aria-label="Standort zurücksetzen"
+            className="flex items-center justify-center h-6 w-6 rounded-full
+                       text-muted-foreground hover:text-destructive hover:bg-destructive/10
+                       transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ) : (
+        /* ── Input mode ── */
+        <>
+          <div className="relative">
+            <MapPin className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+            <Input
+              ref={inputRef}
+              value={value}
+              autoFocus={autoFocus}
+              placeholder="z. B. Regal B-03"
+              className="pl-8"
+              onChange={(e) => {
+                onChange(e.target.value);
+                setOpen(true);
               }}
+              onFocus={() => setOpen(true)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setOpen(false);
+              }}
+            />
+          </div>
+
+          {hint && (
+            <p className="text-xs text-warning leading-tight">{hint}</p>
+          )}
+
+          {open && filtered.length > 0 && (
+            <ul
+              className="absolute z-50 top-full mt-1 w-full rounded-md border border-border
+                         bg-popover shadow-md overflow-hidden"
+              role="listbox"
             >
-              <span>{loc.location}</span>
-              <span className="text-xs text-muted-foreground">
-                {loc.count} {loc.count === 1 ? "Buch" : "Bücher"}
-              </span>
-            </li>
-          ))}
-        </ul>
+              {filtered.map((loc) => (
+                <li
+                  key={loc.location}
+                  role="option"
+                  aria-selected={loc.location === value}
+                  className="flex items-center justify-between px-3 py-2 text-sm
+                             cursor-pointer hover:bg-muted select-none"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(loc);
+                  }}
+                >
+                  <span>{loc.location}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {loc.count} {loc.count === 1 ? "Buch" : "Bücher"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/book/edit/LocationCombobox.tsx
+++ b/components/book/edit/LocationCombobox.tsx
@@ -1,0 +1,121 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { LocationEntry } from "@/pages/api/book/locations";
+import { MapPin } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface LocationComboboxProps {
+  value: string;
+  onChange: (v: string) => void;
+  label?: string;
+  autoFocus?: boolean;
+}
+
+export default function LocationCombobox({
+  value,
+  onChange,
+  label = "Standort",
+  autoFocus = false,
+}: LocationComboboxProps) {
+  const [allLocations, setAllLocations] = useState<LocationEntry[]>([]);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch("/api/book/locations")
+      .then((r) => r.json())
+      .then((data: LocationEntry[]) => setAllLocations(data))
+      .catch(() => {});
+  }, []);
+
+  const filtered = value.trim()
+    ? allLocations.filter((l) =>
+        l.location.toLowerCase().includes(value.toLowerCase()),
+      )
+    : allLocations;
+
+  const exactMatch = allLocations.find(
+    (l) => l.location.toLowerCase() === value.trim().toLowerCase(),
+  );
+
+  const hint =
+    value.trim() === ""
+      ? null
+      : exactMatch
+        ? `Vorhandener Standort · ${exactMatch.count} ${exactMatch.count === 1 ? "Buch" : "Bücher"}`
+        : `Neuer Standort wird erstellt: „${value.trim()}"`;
+
+  const hintColor = exactMatch ? "text-success" : "text-warning";
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative flex flex-col gap-1.5">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+
+      <div className="relative">
+        <MapPin className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+        <Input
+          value={value}
+          autoFocus={autoFocus}
+          placeholder="z. B. Regal B-03"
+          className="pl-8"
+          onChange={(e) => {
+            onChange(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setOpen(false);
+          }}
+        />
+      </div>
+
+      {/* Hint */}
+      {hint && (
+        <p className={`text-xs ${hintColor} leading-tight`}>{hint}</p>
+      )}
+
+      {/* Dropdown */}
+      {open && filtered.length > 0 && (
+        <ul
+          className="absolute z-50 top-full mt-1 w-full rounded-md border border-border
+                     bg-popover shadow-md overflow-hidden"
+          role="listbox"
+        >
+          {filtered.map((loc) => (
+            <li
+              key={loc.location}
+              role="option"
+              aria-selected={loc.location === value}
+              className="flex items-center justify-between px-3 py-2 text-sm
+                         cursor-pointer hover:bg-muted select-none"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onChange(loc.location);
+                setOpen(false);
+              }}
+            >
+              <span>{loc.location}</span>
+              <span className="text-xs text-muted-foreground">
+                {loc.count} {loc.count === 1 ? "Buch" : "Bücher"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/book/edit/LocationCombobox.tsx
+++ b/components/book/edit/LocationCombobox.tsx
@@ -20,6 +20,14 @@ export default function LocationCombobox({
   const [allLocations, setAllLocations] = useState<LocationEntry[]>([]);
   const [open, setOpen] = useState(false);
   const [locked, setLocked] = useState(false);
+  // Typing is not choosing. Without this the sync effect below locked the
+  // field the moment the text happened to equal a known location, so anyone
+  // extending "Regal B" to "Regal B-03" was frozen at the "B" and had to
+  // unlock and start over. Locking follows an explicit pick or a value that
+  // arrived from the outside (an already stored location), never a keystroke.
+  // Holding the typed text rather than a flag keeps that true across a reset:
+  // once `value` no longer matches it, the change came from outside.
+  const typedRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -30,9 +38,9 @@ export default function LocationCombobox({
       .catch(() => {});
   }, []);
 
-  // Sync locked state whenever value or known locations change
+  // Locks a stored location once the list arrives; a typed value is left alone.
   useEffect(() => {
-    if (!allLocations.length) return;
+    if (!allLocations.length || typedRef.current === value) return;
     const isKnown =
       value.trim() !== "" &&
       allLocations.some(
@@ -55,16 +63,18 @@ export default function LocationCombobox({
     locked || value.trim() === ""
       ? null
       : exactMatch
-        ? null // locked state handles this case
+        ? `Vorhandener Standort: „${exactMatch.location}"`
         : `Neuer Standort wird erstellt: „${value.trim()}"`;
 
   const handleSelect = (loc: LocationEntry) => {
+    typedRef.current = null;
     onChange(loc.location);
     setLocked(true);
     setOpen(false);
   };
 
   const handleUnlock = () => {
+    typedRef.current = "";
     onChange("");
     setLocked(false);
     setOpen(false);
@@ -122,6 +132,7 @@ export default function LocationCombobox({
               placeholder="z. B. Regal B-03"
               className="pl-8"
               onChange={(e) => {
+                typedRef.current = e.target.value;
                 onChange(e.target.value);
                 setOpen(true);
               }}
@@ -133,7 +144,13 @@ export default function LocationCombobox({
           </div>
 
           {hint && (
-            <p className="text-xs text-warning leading-tight">{hint}</p>
+            <p
+              className={`text-xs leading-tight ${
+                exactMatch ? "text-muted-foreground" : "text-warning"
+              }`}
+            >
+              {hint}
+            </p>
           )}
 
           {open && filtered.length > 0 && (

--- a/components/labels/editor/FieldAssigner.tsx
+++ b/components/labels/editor/FieldAssigner.tsx
@@ -37,6 +37,7 @@ const CONTENT_OPTIONS: { value: LabelFieldContent; label: string }[] = [
   { value: "id", label: "Buchnummer" },
   { value: "school", label: "Schulname" },
   { value: "topics", label: "Themen (max. 3)" },
+  { value: "location", label: "Standort" },
   { value: "barcode", label: "Barcode" },
   { value: "none", label: "Leer" },
 ];

--- a/components/labels/editor/FieldAssigner.tsx
+++ b/components/labels/editor/FieldAssigner.tsx
@@ -22,6 +22,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { translations } from "@/entities/fieldTranslations";
 import type {
   LabelFieldConfig,
   LabelFieldContent,
@@ -37,7 +38,7 @@ const CONTENT_OPTIONS: { value: LabelFieldContent; label: string }[] = [
   { value: "id", label: "Buchnummer" },
   { value: "school", label: "Schulname" },
   { value: "topics", label: "Themen (max. 3)" },
-  { value: "location", label: "Standort" },
+  { value: "location", label: translations.books.location },
   { value: "barcode", label: "Barcode" },
   { value: "none", label: "Leer" },
 ];

--- a/components/labels/editor/LabelPreview.tsx
+++ b/components/labels/editor/LabelPreview.tsx
@@ -18,6 +18,7 @@ const SAMPLE_BOOK = {
   author: "Antoine de Saint-Exupéry",
   subtitle: "Eine Erzählung",
   topics: "Abenteuer; Freundschaft; Philosophie; Kinderbuch",
+  location: "Regal B-03",
 };
 
 interface LabelPreviewProps {

--- a/cypress/e2e/xlsdownload.cy.ts
+++ b/cypress/e2e/xlsdownload.cy.ts
@@ -60,7 +60,8 @@ describe("Excel Export", () => {
         expect(columns).to.include("Update am");
         expect(columns).to.include("Ausgeliehen am");
         expect(columns).to.include("Rückgabe am");
-        expect(columns.length).to.eq(29);
+        // 30 since the location column was added to the export.
+        expect(columns.length).to.eq(30);
       },
     );
 

--- a/entities/BookType.ts
+++ b/entities/BookType.ts
@@ -28,5 +28,6 @@ export interface BookType {
   additionalMaterial?: string;
   price?: string;
   externalLinks?: string;
+  location?: string;
   userId?: number;
 }

--- a/entities/fieldTranslations.ts
+++ b/entities/fieldTranslations.ts
@@ -65,6 +65,7 @@ const fieldTranslationsDe = {
     additionalMaterial: "Material",
     price: "Preis",
     externalLinks: "Externe Links",
+    location: "Standort",
   },
   rentals: {
     id: "id",
@@ -144,6 +145,7 @@ const fieldTranslationsEn: typeof fieldTranslationsDe = {
     additionalMaterial: "Accompanying material",
     price: "Price",
     externalLinks: "External links",
+    location: "Location",
   },
   rentals: {
     id: "id",

--- a/hooks/useBookSearch.ts
+++ b/hooks/useBookSearch.ts
@@ -14,6 +14,7 @@ const SEARCHABLE_FIELDS = [
   "subtitle",
   "isbn",
   "id",
+  "location",
 ] as const;
 const DEBOUNCE_MS = 150;
 

--- a/lib/labels/renderLabelSheet.tsx
+++ b/lib/labels/renderLabelSheet.tsx
@@ -227,6 +227,9 @@ function getFieldText(
     case "id":
       text = book.id || "";
       break;
+    case "location":
+      text = book.location || "";
+      break;
     case "school":
       text = process.env.SCHOOL_NAME || "";
       break;

--- a/lib/labels/types.ts
+++ b/lib/labels/types.ts
@@ -67,6 +67,7 @@ export type LabelFieldContent =
   | "barcode"
   | "school"
   | "topics"
+  | "location"
   | "none";
 
 export type TextAlign = "left" | "center" | "right";
@@ -124,6 +125,7 @@ export interface BookLabelData {
   subtitle?: string;
   isbn?: string;
   topics?: string;
+  location?: string;
 }
 
 /** Filter to select books from the database */

--- a/lib/labels/types.ts
+++ b/lib/labels/types.ts
@@ -130,10 +130,10 @@ export interface BookLabelData {
 
 /** Filter to select books from the database */
 export interface BookFilter {
-  type: "latest" | "topic" | "all" | "ids";
+  type: "latest" | "topic" | "location" | "all" | "ids";
   /** For "latest": number of most recent books */
   count?: number;
-  /** For "topic": topic/category string to match */
+  /** For "topic" / "location": values to match against */
   values?: string[];
   /** For "ids": explicit list of book IDs */
   ids?: number[];

--- a/lib/utils/xlsColumnsMapping.ts
+++ b/lib/utils/xlsColumnsMapping.ts
@@ -27,6 +27,7 @@ export const xlsbookcolumns = [
   { key: "additionalMaterial", header: "Material" },
   { key: "price", header: "Preis" },
   { key: "externalLinks", header: "Links" },
+  { key: "location", header: "Standort" },
   { key: "userId", header: "Ausgeliehen von" },
 ];
 

--- a/pages/api/book/locations.ts
+++ b/pages/api/book/locations.ts
@@ -1,0 +1,35 @@
+import { prisma, reconnectPrisma } from "@/entities/db";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface LocationEntry {
+  location: string;
+  count: number;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<LocationEntry[] | { result: string }>,
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end(`${req.method} Not Allowed`);
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    await reconnectPrisma();
+  }
+
+  const groups = await prisma.book.groupBy({
+    by: ["location"],
+    where: { location: { not: null } },
+    _count: { location: true },
+    orderBy: { _count: { location: "desc" } },
+  });
+
+  const locations: LocationEntry[] = groups
+    .filter((g) => g.location && g.location.trim() !== "")
+    .map((g) => ({ location: g.location as string, count: g._count.location }));
+
+  res.setHeader("Cache-Control", "no-store");
+  return res.status(200).json(locations);
+}

--- a/pages/api/excel/index.ts
+++ b/pages/api/excel/index.ts
@@ -271,6 +271,7 @@ export default async function handle(
                   additionalMaterial: b["Material"],
                   price: b["Preis"],
                   externalLinks: b["Links"],
+                  location: b["Standort"],
                   userId: b["Ausgeliehen von"],
                 },
               }),

--- a/pages/api/labels/generate.ts
+++ b/pages/api/labels/generate.ts
@@ -70,6 +70,22 @@ async function resolveBookFilter(filter: BookFilter): Promise<BookLabelData[]> {
       break;
     }
 
+    case "location": {
+      const selectedLocations = (filter.values ?? []).map((v) =>
+        v.toLowerCase(),
+      );
+      if (selectedLocations.length === 0) {
+        filtered = [];
+      } else {
+        filtered = allBooks.filter((b) =>
+          selectedLocations.some((loc) =>
+            b.location?.toLowerCase().includes(loc),
+          ),
+        );
+      }
+      break;
+    }
+
     case "ids":
       if (!filter.ids || filter.ids.length === 0) {
         filtered = [];
@@ -88,9 +104,9 @@ async function resolveBookFilter(filter: BookFilter): Promise<BookLabelData[]> {
     title: b.title ?? "",
     author: b.author ?? "",
     subtitle: b.subtitle ?? "",
-    isbn: b.isbn ?? undefined,
-    topics: b.topics ?? undefined,
-    location: b.location ?? undefined,
+    isbn: b.isbn ?? "",
+    topics: b.topics ?? "",
+    location: b.location ?? "",
   }));
 }
 

--- a/pages/api/labels/generate.ts
+++ b/pages/api/labels/generate.ts
@@ -90,6 +90,7 @@ async function resolveBookFilter(filter: BookFilter): Promise<BookLabelData[]> {
     subtitle: b.subtitle ?? "",
     isbn: b.isbn ?? undefined,
     topics: b.topics ?? undefined,
+    location: b.location ?? undefined,
   }));
 }
 

--- a/pages/book/batchscan.tsx
+++ b/pages/book/batchscan.tsx
@@ -1,3 +1,4 @@
+import LocationCombobox from "@/components/book/edit/LocationCombobox";
 import type { ScannedEntry } from "@/components/batch-scan";
 import {
   BatchScanEntryCard,
@@ -43,6 +44,7 @@ export default function BatchScan() {
   const [entries, setEntries] = useState<ScannedEntry[]>([]);
   const [isImporting, setIsImporting] = useState(false);
   const [importProgress, setImportProgress] = useState(0);
+  const [batchLocation, setBatchLocation] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -94,7 +96,7 @@ export default function BatchScan() {
       id: generateId(),
       isbn: cleanedIsbn,
       status: "loading",
-      bookData: { isbn: cleanedIsbn },
+      bookData: { isbn: cleanedIsbn, location: batchLocation || undefined },
       quantity: 1,
     };
 
@@ -324,6 +326,7 @@ export default function BatchScan() {
           physicalSize: entry.bookData.physicalSize,
           otherPhysicalAttributes: entry.bookData.otherPhysicalAttributes,
           editionDescription: entry.bookData.editionDescription,
+          location: entry.bookData.location || undefined,
         };
 
         try {
@@ -382,6 +385,20 @@ export default function BatchScan() {
 
     inputRef.current?.focus();
   }, [entries]);
+
+  // ── Apply batch location to all entries ───────────────────────────────────
+
+  const handleApplyLocationToAll = useCallback(() => {
+    if (!batchLocation.trim()) return;
+    setEntries((prev) =>
+      prev.map((entry) => ({
+        ...entry,
+        bookData: { ...entry.bookData, location: batchLocation },
+        status: entry.status === "found" ? "edited" : entry.status,
+      })),
+    );
+    toast.success(`Standort „${batchLocation}" auf alle Einträge angewendet`);
+  }, [batchLocation]);
 
   // ── Clear all ─────────────────────────────────────────────────────────────
 
@@ -555,6 +572,35 @@ export default function BatchScan() {
               </CardContent>
             </Card>
           )}
+
+          {/* Batch location preset */}
+          <Card className="mb-4">
+            <CardContent className="pt-5 pb-4">
+              <h2 className="text-base font-semibold mb-3">
+                Standort für alle Bücher
+              </h2>
+              <div className="flex flex-col sm:flex-row gap-3 items-end">
+                <div className="flex-1">
+                  <LocationCombobox
+                    value={batchLocation}
+                    onChange={setBatchLocation}
+                    label="Standard-Standort"
+                  />
+                </div>
+                {entries.length > 0 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleApplyLocationToAll}
+                    disabled={!batchLocation.trim()}
+                    className="shrink-0 h-9"
+                  >
+                    Auf alle anwenden
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
 
           {/* Entries List */}
           {entries.length === 0 ? (

--- a/pages/book/batchscan.tsx
+++ b/pages/book/batchscan.tsx
@@ -10,6 +10,11 @@ import {
 import Layout from "@/components/layout/Layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { BookType } from "@/entities/BookType";
@@ -19,11 +24,13 @@ import { generateId } from "@/lib/utils/id";
 import {
   AlertTriangle,
   CheckCircle,
+  ChevronDown,
   Image,
   Loader2,
   PlusCircle,
   Save,
   ScanBarcode,
+  Settings2,
 } from "lucide-react";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -45,6 +52,7 @@ export default function BatchScan() {
   const [isImporting, setIsImporting] = useState(false);
   const [importProgress, setImportProgress] = useState(0);
   const [batchLocation, setBatchLocation] = useState("");
+  const [presetOpen, setPresetOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -573,34 +581,54 @@ export default function BatchScan() {
             </Card>
           )}
 
-          {/* Batch location preset */}
-          <Card className="mb-4">
-            <CardContent className="pt-5 pb-4">
-              <h2 className="text-base font-semibold mb-3">
-                Standort für alle Bücher
-              </h2>
-              <div className="flex flex-col sm:flex-row gap-3 items-end">
-                <div className="flex-1">
-                  <LocationCombobox
-                    value={batchLocation}
-                    onChange={setBatchLocation}
-                    label="Standard-Standort"
-                  />
-                </div>
-                {entries.length > 0 && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleApplyLocationToAll}
-                    disabled={!batchLocation.trim()}
-                    className="shrink-0 h-9"
-                  >
-                    Auf alle anwenden
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          {/* Book preset properties */}
+          <Collapsible open={presetOpen} onOpenChange={setPresetOpen}>
+            <Card className="mb-4">
+              <CardContent className="pt-4 pb-4">
+                <CollapsibleTrigger asChild>
+                  <button className="flex w-full items-center justify-between gap-2 text-left">
+                    <div className="flex items-center gap-2">
+                      <Settings2 className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-base font-semibold">
+                        Buchvoreinstellungen
+                      </span>
+                      {batchLocation && (
+                        <span className="text-xs text-muted-foreground font-normal">
+                          · {batchLocation}
+                        </span>
+                      )}
+                    </div>
+                    <ChevronDown
+                      className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${presetOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                </CollapsibleTrigger>
+
+                <CollapsibleContent className="mt-4">
+                  <div className="flex flex-col sm:flex-row gap-3 items-end">
+                    <div className="flex-1">
+                      <LocationCombobox
+                        value={batchLocation}
+                        onChange={setBatchLocation}
+                        label="Standard-Standort"
+                      />
+                    </div>
+                    {entries.length > 0 && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleApplyLocationToAll}
+                        disabled={!batchLocation.trim()}
+                        className="shrink-0 h-9"
+                      >
+                        Auf alle anwenden
+                      </Button>
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </CardContent>
+            </Card>
+          </Collapsible>
 
           {/* Entries List */}
           {entries.length === 0 ? (

--- a/prisma/migrations/20260626000000_add_book_location/migration.sql
+++ b/prisma/migrations/20260626000000_add_book_location/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Book" ADD COLUMN "location" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model Book {
   //why is this string? In the migration, there were often DM prices or some other text
   price                   String?
   externalLinks           String?
+  location                String?
 
   user   User? @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId Int?


### PR DESCRIPTION
Closes #437

Adds a physical location field to books so staff can track where books live on the shelf.

The input is a combobox that autocompletes from location values already in the database. Picking an existing location locks it as a tag showing the name and count. Typing something new shows a warning that a new location will be created. Clicking the x on the tag unlocks it.

Batch scan gets a collapsible preset panel above the entries list. Set a location once and all newly scanned books inherit it. There is also an apply-to-all button for books already in the list. Each entry can still override the preset from its own edit panel.

Location is also wired into labels (assignable field in the template editor), the Excel export, and the book search index.