### PR TITLE
Make login page background image configurable via LOGIN_IMAGE

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -96,6 +96,10 @@ REMINDER_RENEWAL_COUNT=5
 # 🖼️ Background template for user ID labels (filename in /public directory)
 USERID_LABEL_IMAGE=userlabeltemplate.jpg
 
+# 🖼️ Login page background image (filename in /public directory)
+# Leave unset to use the built-in default splash image.
+# LOGIN_IMAGE="schule_login.jpg"
+
 # 📐 Size and layout
 USERLABEL_WIDTH="42vw"
 USERLABEL_PER_PAGE=6

--- a/doc/mkdocs/docs/configuration/environment-variables.md
+++ b/doc/mkdocs/docs/configuration/environment-variables.md
@@ -20,11 +20,15 @@ DATABASE_URL=file:./database/dev.db
 | `AUTH_ENABLED`     | Login erforderlich?              | `true`                  |
 | `NEXTAUTH_SECRET`  | Geheimer Seed für Session-Tokens | _(muss gesetzt werden)_ |
 | `SECURITY_HEADERS` | CSRP headers für HTTP calls      | `insecure`              |
+| `LOGIN_IMAGE`      | Hintergrundbild der Login-Seite  | _(leer, eingebautes Standardbild)_ |
 
 ```env
 AUTH_ENABLED=true
 NEXTAUTH_SECRET=einLangesZufälligesGeheimnis123!
+LOGIN_IMAGE=schule_login.jpg
 ```
+
+`LOGIN_IMAGE` erwartet den Dateinamen eines Bildes im `/public`-Verzeichnis der App. Bleibt die Variable leer, wird das mitgelieferte Standardbild verwendet.
 
 !!! warning "AUTH_SECRET"
 Verwende einen langen, zufälligen String. Ändere ihn nicht nachträglich, sonst werden alle Nutzer ausgeloggt.

--- a/lib/i18n/de.ts
+++ b/lib/i18n/de.ts
@@ -441,6 +441,12 @@ export const de = {
             description:
               "Zeit in Sekunden bis zur automatischen Abmeldung bei Inaktivität.",
           },
+          LOGIN_IMAGE: {
+            label: "Hintergrundbild der Login-Seite",
+            description:
+              "Dateiname eines Bildes im /public-Verzeichnis, das als Hintergrund der Login-Seite verwendet wird. Leer lassen für das mitgelieferte Standardbild.",
+            hint: "z.B. schule_login.jpg (die Datei muss im /public-Verzeichnis der App liegen).",
+          },
           MAX_MIGRATION_SIZE: {
             label: "Max. Import-Dateigröße",
             description:

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -432,6 +432,12 @@ export const en: Dictionary = {
             description:
               "Time in seconds until automatic logout on inactivity.",
           },
+          LOGIN_IMAGE: {
+            label: "Login page background image",
+            description:
+              "Filename of an image in the /public directory used as the login page background. Leave empty to use the built-in splash image.",
+            hint: "e.g. schule_login.jpg (the file must be in the /public directory of the app).",
+          },
           MAX_MIGRATION_SIZE: {
             label: "Max import file size",
             description:

--- a/lib/i18n/es.ts
+++ b/lib/i18n/es.ts
@@ -440,6 +440,12 @@ export const es: Dictionary = {
             description:
               "Tiempo en segundos hasta el cierre de sesión automático por inactividad.",
           },
+          LOGIN_IMAGE: {
+            label: "Imagen de fondo de la página de inicio de sesión",
+            description:
+              "Nombre de archivo de una imagen en el directorio /public usada como fondo de la página de inicio de sesión. Dejar vacío para usar la imagen predeterminada.",
+            hint: "p. ej. schule_login.jpg (el archivo debe estar en el directorio /public de la aplicación).",
+          },
           MAX_MIGRATION_SIZE: {
             label: "Tamaño máx. de archivo de importación",
             description:

--- a/lib/loginImage.ts
+++ b/lib/loginImage.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve the configured login background image (LOGIN_IMAGE env) to the URL the
+ * login page renders:
+ *   - a bare filename ("schule_login.jpg") is served from /public → "/schule_login.jpg"
+ *   - an already-rooted path ("/img/x.jpg") is returned as-is
+ *   - unset → null, and the login page falls back to the bundled splash
+ *
+ * Same-origin only by design: the CSP is `img-src 'self'`, so the image must be
+ * served from this app (i.e. /public). Shared by the login page (to render it)
+ * and proxy.ts (to let it through the auth gate) so the allowlisted path always
+ * matches the requested one.
+ */
+export function resolveLoginImage(): string | null {
+  const raw = process.env.LOGIN_IMAGE?.trim();
+  if (!raw) return null;
+  return raw.startsWith("/") ? raw : `/${raw}`;
+}

--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -186,6 +186,14 @@ const CONFIG_SECTIONS: ConfigSection[] = [
         unit: t("admin.units.seconds"),
       },
       {
+        key: "LOGIN_IMAGE",
+        label: tf("technical", "LOGIN_IMAGE", "label"),
+        description: tf("technical", "LOGIN_IMAGE", "description"),
+        hint: tf("technical", "LOGIN_IMAGE", "hint"),
+        type: "text",
+        default: "",
+      },
+      {
         key: "MAX_MIGRATION_SIZE",
         label: tf("technical", "MAX_MIGRATION_SIZE", "label"),
         description: tf("technical", "MAX_MIGRATION_SIZE", "description"),

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -10,11 +10,16 @@ import { getCsrfToken } from "next-auth/react";
 import Head from "next/head";
 
 import { t } from "@/lib/i18n";
+import { resolveLoginImage } from "@/lib/loginImage";
 import loginsplash from "./loginsplashscreen.jpg";
 
 export default function Login({
   csrfToken,
+  loginImage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  // Configurable via LOGIN_IMAGE (a file in /public); falls back to the bundled
+  // splash when unset.
+  const splashSrc = loginImage ?? loginsplash.src;
   const [user, setUser] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -61,7 +66,7 @@ export default function Login({
         <div
           className="hidden sm:block sm:w-5/12 md:w-7/12 relative"
           style={{
-            backgroundImage: `url(${loginsplash.src})`,
+            backgroundImage: `url(${splashSrc})`,
             backgroundRepeat: "no-repeat",
             backgroundSize: "cover",
             backgroundPosition: "center",
@@ -163,9 +168,12 @@ export default function Login({
 }
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const loginImage = resolveLoginImage();
+
   return {
     props: {
       csrfToken: (await getCsrfToken(context)) ?? null,
+      loginImage,
     },
   };
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,3 +1,4 @@
+import { resolveLoginImage } from "@/lib/loginImage";
 import { withAuth } from "next-auth/middleware";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -41,12 +42,16 @@ export default withAuth(
 
         // Routes explicitly excluded from authentication.
         // Keep this list narrow — every entry here is a public attack surface.
+        // The configured login background lives in /public and must load on the
+        // (unauthenticated) login page, so allow exactly that one file.
+        const loginImage = resolveLoginImage();
         const isPublicRoute =
           pathname === "/publicbookview" ||
           pathname === "/catalog" ||
           pathname.startsWith("/api/images") ||
           pathname === "/api/version" ||
-          pathname.startsWith("/api/public/");
+          pathname.startsWith("/api/public/") ||
+          (loginImage !== null && pathname === loginImage);
 
         if (isPublicRoute) return true;
 


### PR DESCRIPTION
Closes #418

The login page hardcoded the bundled splash image. This wires the already-documented `LOGIN_IMAGE` env var so each deployment can set its own login background.

## What changed
- `getServerSideProps` reads `LOGIN_IMAGE` (a filename in `/public`) and the login page uses it, falling back to the bundled splash when unset.
- A shared helper (`lib/loginImage.ts`) resolves the path for both the login page and `proxy.ts`, so the auth allowlist matches the URL the page requests — otherwise the `/public` image is gated and 307-redirected to login, leaving the background blank.
- Documented in `.env_example`.

## Notes
- Same-origin only by design (the CSP is `img-src 'self'`).
- The deployment's actual image is provided per install, not committed to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)