### PR TITLE
Fix public catalog book detail page 404 behind HTTPS

### DIFF
--- a/entities/publicBook.ts
+++ b/entities/publicBook.ts
@@ -1,0 +1,108 @@
+import { PublicBookDetailType } from "@/entities/PublicBookDetailType";
+import { PublicBookType } from "@/entities/PublicBookType";
+import { Prisma, PrismaClient } from "@prisma/client";
+
+const RELATED_LIMIT = 5;
+// Bound on rows fetched for related-book ranking. Ranking beyond this many
+// candidates is approximate, which is acceptable for a 5-item suggestion list.
+const RELATED_CANDIDATE_LIMIT = 200;
+
+/**
+ * The Prisma `select` counterpart of PublicBookType: the only book fields that
+ * may be fetched for unauthenticated responses. Keep in sync with that type.
+ */
+export const PUBLIC_BOOK_SELECT = {
+  id: true,
+  title: true,
+  author: true,
+  isbn: true,
+  topics: true,
+  rentalStatus: true,
+} satisfies Prisma.BookSelect;
+
+type PublicBookRow = Prisma.BookGetPayload<{ select: typeof PUBLIC_BOOK_SELECT }>;
+
+export function toPublicBook(b: PublicBookRow): PublicBookType {
+  return {
+    id: b.id,
+    title: b.title,
+    author: b.author,
+    isbn: b.isbn,
+    topics: b.topics,
+    rentalStatus: b.rentalStatus,
+    coverUrl: `/api/images/${b.id}`,
+  };
+}
+
+export function parseTopics(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(";")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Public detail view for a single book, plus a few related books that share
+ * topics. Returns null when the book does not exist.
+ *
+ * Whitelisted `select` only (see PublicBookType) so no PII-adjacent field can
+ * leak. Shared by the API route (/api/public/books/[id]) and the catalog detail
+ * page's getServerSideProps, so the page reads the DB directly instead of making
+ * an HTTP round-trip to its own API (which breaks under HTTPS and is slower).
+ */
+export async function getPublicBookDetail(
+  client: PrismaClient,
+  id: number,
+): Promise<PublicBookDetailType | null> {
+  const book = await client.book.findUnique({
+    where: { id },
+    select: {
+      ...PUBLIC_BOOK_SELECT,
+      subtitle: true,
+      summary: true,
+      publisherName: true,
+      publisherDate: true,
+      pages: true,
+      minAge: true,
+      maxAge: true,
+    },
+  });
+
+  if (!book) return null;
+
+  const topics = parseTopics(book.topics);
+
+  let relatedBooks: PublicBookType[] = [];
+  if (topics.length > 0) {
+    const candidates = await client.book.findMany({
+      where: {
+        id: { not: id },
+        OR: topics.map((topic) => ({ topics: { contains: topic } })),
+      },
+      select: PUBLIC_BOOK_SELECT,
+      take: RELATED_CANDIDATE_LIMIT,
+    });
+
+    relatedBooks = candidates
+      .map((b) => ({
+        book: b,
+        shared: parseTopics(b.topics).filter((t) => topics.includes(t)).length,
+      }))
+      .sort((a, b) => b.shared - a.shared)
+      .slice(0, RELATED_LIMIT)
+      .map(({ book: b }) => toPublicBook(b));
+  }
+
+  return {
+    ...toPublicBook(book),
+    subtitle: book.subtitle,
+    summary: book.summary,
+    publisherName: book.publisherName,
+    publisherDate: book.publisherDate,
+    pages: book.pages,
+    minAge: book.minAge,
+    maxAge: book.maxAge,
+    relatedBooks,
+  };
+}

--- a/pages/api/public/books.ts
+++ b/pages/api/public/books.ts
@@ -1,5 +1,6 @@
 import { PublicBookType } from "@/entities/PublicBookType";
 import { prisma, reconnectPrisma } from "@/entities/db";
+import { PUBLIC_BOOK_SELECT, toPublicBook } from "@/entities/publicBook";
 import { LogEvents } from "@/lib/logEvents";
 import { businessLogger, errorLogger } from "@/lib/logger";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -42,29 +43,14 @@ export default async function handler(
 
   try {
     const rawBooks = await prisma.book.findMany({
-      select: {
-        id: true,
-        title: true,
-        author: true,
-        isbn: true,
-        topics: true,
-        rentalStatus: true,
-      },
+      select: PUBLIC_BOOK_SELECT,
       orderBy: { title: "asc" },
     });
 
-    const books: Array<PublicBookType> = rawBooks.map((b) => ({
-      id: b.id,
-      title: b.title,
-      author: b.author,
-      isbn: b.isbn,
-      topics: b.topics,
-      rentalStatus: b.rentalStatus,
-      // Cover is served by /api/images/[id], which handles the .jpg lookup
-      // and default.jpg fallback. That route is already excluded from auth
-      // in middleware.ts so unauthenticated clients can fetch it directly.
-      coverUrl: `/api/images/${b.id}`,
-    }));
+    // Cover is served by /api/images/[id], which handles the .jpg lookup
+    // and default.jpg fallback. That route is already excluded from auth
+    // in middleware.ts so unauthenticated clients can fetch it directly.
+    const books: Array<PublicBookType> = rawBooks.map(toPublicBook);
 
     businessLogger.info(
       {

--- a/pages/api/public/books/[id].ts
+++ b/pages/api/public/books/[id].ts
@@ -1,16 +1,9 @@
 import { PublicBookDetailType } from "@/entities/PublicBookDetailType";
-import { PublicBookType } from "@/entities/PublicBookType";
 import { prisma, reconnectPrisma } from "@/entities/db";
+import { getPublicBookDetail } from "@/entities/publicBook";
 import { LogEvents } from "@/lib/logEvents";
 import { errorLogger } from "@/lib/logger";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-const RELATED_LIMIT = 5;
-
-function parseTopics(raw: string | null | undefined): string[] {
-  if (!raw) return [];
-  return raw.split(";").map((t) => t.trim()).filter(Boolean);
-}
 
 export default async function handler(
   req: NextApiRequest,
@@ -33,84 +26,10 @@ export default async function handler(
   res.setHeader("Cache-Control", "public, max-age=60, s-maxage=300");
 
   try {
-    const book = await prisma.book.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        title: true,
-        author: true,
-        isbn: true,
-        topics: true,
-        rentalStatus: true,
-        subtitle: true,
-        summary: true,
-        publisherName: true,
-        publisherDate: true,
-        pages: true,
-        minAge: true,
-        maxAge: true,
-      },
-    });
-
-    if (!book) {
+    const detail = await getPublicBookDetail(prisma, id);
+    if (!detail) {
       return res.status(404).json({ result: "Book not found" });
     }
-
-    const topics = parseTopics(book.topics);
-
-    let relatedBooks: PublicBookType[] = [];
-    if (topics.length > 0) {
-      const candidates = await prisma.book.findMany({
-        where: {
-          id: { not: id },
-          OR: topics.map((topic) => ({ topics: { contains: topic } })),
-        },
-        select: {
-          id: true,
-          title: true,
-          author: true,
-          isbn: true,
-          topics: true,
-          rentalStatus: true,
-        },
-      });
-
-      relatedBooks = candidates
-        .map((b) => ({
-          book: b,
-          shared: parseTopics(b.topics).filter((t) => topics.includes(t)).length,
-        }))
-        .sort((a, b) => b.shared - a.shared)
-        .slice(0, RELATED_LIMIT)
-        .map(({ book: b }) => ({
-          id: b.id,
-          title: b.title,
-          author: b.author,
-          isbn: b.isbn,
-          topics: b.topics,
-          rentalStatus: b.rentalStatus,
-          coverUrl: `/api/images/${b.id}`,
-        }));
-    }
-
-    const detail: PublicBookDetailType = {
-      id: book.id,
-      title: book.title,
-      author: book.author,
-      isbn: book.isbn,
-      topics: book.topics,
-      rentalStatus: book.rentalStatus,
-      coverUrl: `/api/images/${book.id}`,
-      subtitle: book.subtitle,
-      summary: book.summary,
-      publisherName: book.publisherName,
-      publisherDate: book.publisherDate,
-      pages: book.pages,
-      minAge: book.minAge,
-      maxAge: book.maxAge,
-      relatedBooks,
-    };
-
     return res.status(200).json(detail);
   } catch (error) {
     errorLogger.error(

--- a/pages/catalog/[id].tsx
+++ b/pages/catalog/[id].tsx
@@ -3,12 +3,9 @@ import Layout from "@/components/layout/Layout";
 import { BookType } from "@/entities/BookType";
 import { PublicBookDetailType } from "@/entities/PublicBookDetailType";
 import { PublicBookType } from "@/entities/PublicBookType";
+import { prisma, reconnectPrisma } from "@/entities/db";
+import { getPublicBookDetail, parseTopics } from "@/entities/publicBook";
 import { translations } from "@/entities/fieldTranslations";
-
-function parseTopics(raw: string | null | undefined): string[] {
-  if (!raw) return [];
-  return raw.split(";").map((t) => t.trim()).filter(Boolean);
-}
 import { t } from "@/lib/i18n";
 import { ArrowLeft, BookOpen, Calendar, Hash, Tag, Users } from "lucide-react";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
@@ -320,19 +317,24 @@ export default function CatalogDetailPage({ book }: CatalogDetailProps) {
 export const getServerSideProps: GetServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
-  const host = context.req.headers.host ?? "localhost:3000";
-  const baseUrl = `http://${host}`;
+  const id = parseInt(context.params?.id as string, 10);
+  if (Number.isNaN(id)) {
+    return { notFound: true };
+  }
 
-  const id = context.params?.id as string;
+  if (process.env.NODE_ENV !== "production") {
+    await reconnectPrisma();
+  }
 
   try {
-    const res = await fetch(`${baseUrl}/api/public/books/${id}`);
-
-    if (!res.ok) {
+    // Read the DB directly rather than fetching our own API over HTTP: the
+    // self-fetch broke under HTTPS (an http:// request against an https:// port)
+    // and is a needless round-trip. getPublicBookDetail applies the same public
+    // field whitelist the API uses.
+    const book = await getPublicBookDetail(prisma, id);
+    if (!book) {
       return { notFound: true };
     }
-
-    const book: PublicBookDetailType = await res.json();
     return { props: { book } };
   } catch (error) {
     console.error("Error fetching catalog book detail:", error);

--- a/proxy.ts
+++ b/proxy.ts
@@ -44,6 +44,7 @@ export default withAuth(
         const isPublicRoute =
           pathname === "/publicbookview" ||
           pathname === "/catalog" ||
+          pathname.startsWith("/catalog/") ||
           pathname.startsWith("/api/images") ||
           pathname === "/api/version" ||
           pathname.startsWith("/api/public/");


### PR DESCRIPTION
Fixes #447.

The detail page /catalog/[id] returned a 404 for existing books on HTTPS deployments. getServerSideProps fetched its own API with a hardcoded http scheme built from the host header, which fails behind a TLS terminating proxy, and the error got swallowed into notFound.

The page now reads the database directly through a shared getPublicBookDetail() in entities/publicBook.ts, the same helper the API route /api/public/books/[id] now uses, so both paths keep the identical whitelisted field selection and the self HTTP round trip is gone. Along the way the related books query got bounded with take: 200 instead of loading every book that shares a topic, and the duplicated parseTopics on the page was replaced with a shared export.

The login redirect half of #447 is already fixed on main since #449 allowlisted /catalog/ in the proxy, so this PR is rebased on current main and now covers only the HTTPS fix. It deliberately leaves getPublicBooks in entities/book.ts as is.

Tested with a production build against a real library database: the detail page renders 200 unauthenticated, related books come back ranked by shared topics, invalid and unknown ids return 404.