### PR TITLE
Move book list pagination and search to the server

### DIFF
--- a/components/book/SummaryRowContainer.tsx
+++ b/components/book/SummaryRowContainer.tsx
@@ -3,9 +3,13 @@ import { BookType } from "@/entities/BookType";
 import { t } from "@/lib/i18n";
 import { memo, useMemo } from "react";
 
+type SummaryBook = BookType & { copyCount?: number };
+
 interface SummaryRowContainerProps {
-  renderedBooks: BookType[];
+  renderedBooks: SummaryBook[];
   pageIndex: number;
+  totalBooks: number;
+  maxBooks: number;
   onLoadMore: () => void;
   onCopyBook: (book: BookType) => void;
 }
@@ -13,11 +17,13 @@ interface SummaryRowContainerProps {
 const SummaryRowContainer = memo(function SummaryRowContainer({
   renderedBooks,
   pageIndex,
+  totalBooks,
+  maxBooks,
   onLoadMore,
   onCopyBook,
 }: SummaryRowContainerProps) {
   const groupedBooks = useMemo(() => {
-    const map = new Map<string, BookType[]>();
+    const map = new Map<string, SummaryBook[]>();
 
     for (const book of renderedBooks) {
       const key = book.isbn?.trim() ? book.isbn.trim() : `__no_isbn_${book.id}`;
@@ -29,9 +35,15 @@ const SummaryRowContainer = memo(function SummaryRowContainer({
     return Array.from(map.values()).map((group) => {
       const representative =
         group.find((b) => b.rentalStatus !== "rented") ?? group[0];
-      return { book: representative, count: group.length };
+      const copyCount = Math.max(
+        group.length,
+        ...group.map((book) => book.copyCount ?? 0),
+      );
+      return { book: representative, count: copyCount };
     });
   }, [renderedBooks]);
+
+  const visibleLimit = Math.min(totalBooks, maxBooks);
 
   return (
     <div className="flex flex-col gap-2 w-full">
@@ -43,14 +55,14 @@ const SummaryRowContainer = memo(function SummaryRowContainer({
           handleCopyBook={() => onCopyBook(book)}
         />
       ))}
-      {groupedBooks.length - pageIndex > 0 && (
+      {visibleLimit - renderedBooks.length > 0 && (
         <div className="flex justify-center mt-4">
           <button
             onClick={onLoadMore}
             className="px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors"
           >
             {t("bookPage.loadMore")}{" "}
-            {Math.max(0, groupedBooks.length - pageIndex)}
+            {Math.max(0, visibleLimit - renderedBooks.length)}
           </button>
         </div>
       )}

--- a/components/book/SummaryRowContainer.tsx
+++ b/components/book/SummaryRowContainer.tsx
@@ -7,7 +7,6 @@ type SummaryBook = BookType & { copyCount?: number };
 
 interface SummaryRowContainerProps {
   renderedBooks: SummaryBook[];
-  pageIndex: number;
   totalBooks: number;
   maxBooks: number;
   onLoadMore: () => void;
@@ -16,7 +15,6 @@ interface SummaryRowContainerProps {
 
 const SummaryRowContainer = memo(function SummaryRowContainer({
   renderedBooks,
-  pageIndex,
   totalBooks,
   maxBooks,
   onLoadMore,
@@ -47,7 +45,7 @@ const SummaryRowContainer = memo(function SummaryRowContainer({
 
   return (
     <div className="flex flex-col gap-2 w-full">
-      {groupedBooks.slice(0, pageIndex).map(({ book, count }) => (
+      {groupedBooks.map(({ book, count }) => (
         <BookSummaryRow
           key={book.id}
           book={book}

--- a/cypress/e2e/bookpagination.cy.ts
+++ b/cypress/e2e/bookpagination.cy.ts
@@ -86,6 +86,34 @@ describe("Server-side book pagination", () => {
     });
   });
 
+  it("should return only that book when the search term is its number", () => {
+    // The Mediennummer off a barcode scanner is the common case. Before this
+    // was pinned, the digits also matched as a substring of every ISBN
+    // containing them, so scanning a number returned a handful of books.
+    cy.request(`${API}?pageSize=50`).then((list) => {
+      const books = Array.isArray(list.body) ? list.body : list.body.books;
+      const target = books[0];
+      cy.request(`${API}?pageSize=50&q=${target.id}`).then((res) => {
+        expect(res.body.total).to.eq(1);
+        expect(res.body.books[0].id).to.eq(target.id);
+      });
+    });
+  });
+
+  it("should fall back to a text search when no book carries that number", () => {
+    // Digits that are not a book number are meant as text: a year, or a number
+    // inside a title. Those must still search the ordinary fields.
+    cy.request(`${API}?pageSize=50`).then((list) => {
+      const books = Array.isArray(list.body) ? list.body : list.body.books;
+      const freeId = Math.max(...books.map((b: { id: number }) => b.id)) + 1000;
+      cy.request(`${API}?pageSize=50&q=${freeId}`).then((res) => {
+        // No book has this id, so the query is treated as text and simply
+        // finds nothing here rather than returning the whole catalogue.
+        expect(res.body.total).to.eq(0);
+      });
+    });
+  });
+
   it("should render the book list page and its search field", () => {
     cy.visit("http://localhost:3000/book");
     cy.get("[data-cy=rental_input_searchbook]").should("be.visible");

--- a/cypress/e2e/bookpagination.cy.ts
+++ b/cypress/e2e/bookpagination.cy.ts
@@ -92,3 +92,5 @@ describe("Server-side book pagination", () => {
     cy.contains("Herr der Diebe").should("be.visible");
   });
 });
+
+export {};

--- a/cypress/e2e/bookpagination.cy.ts
+++ b/cypress/e2e/bookpagination.cy.ts
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+// Paging moved from the browser to the server. Both list pages used to receive
+// the whole catalogue and slice it client side, so memory grew with the size of
+// the library rather than with what is on screen. These specs pin the new query
+// contract and, just as importantly, the unparameterised responses that
+// existing callers still depend on.
+
+const API = "http://localhost:3000/api/book";
+const PUBLIC_API = "http://localhost:3000/api/public/books";
+
+describe("Server-side book pagination", () => {
+  before(() => {
+    cy.resetAndSeed();
+  });
+
+  after(() => {
+    cy.clearDatabase();
+  });
+
+  beforeEach(() => {
+    cy.session("user-session", () => {
+      cy.login();
+    });
+  });
+
+  it("should return one page of books together with the total", () => {
+    cy.request(`${API}?pageSize=5&page=1`).then((res) => {
+      expect(res.status).to.eq(200);
+      expect(res.body.books).to.have.length(5);
+      expect(res.body.page).to.eq(1);
+      expect(res.body.pageSize).to.eq(5);
+      // The seed holds more books than fit on one page, which is the whole
+      // point: total counts the catalogue, not the slice.
+      expect(res.body.total).to.be.greaterThan(5);
+    });
+  });
+
+  it("should return a different slice on the second page", () => {
+    cy.request(`${API}?pageSize=5&page=1`).then((first) => {
+      cy.request(`${API}?pageSize=5&page=2`).then((second) => {
+        const firstIds = first.body.books.map((b: { id: number }) => b.id);
+        const secondIds = second.body.books.map((b: { id: number }) => b.id);
+        expect(second.body.page).to.eq(2);
+        expect(secondIds).to.have.length(5);
+        expect(firstIds.filter((id: number) => secondIds.includes(id))).to.be
+          .empty;
+      });
+    });
+  });
+
+  it("should still answer with a plain array when pageSize is omitted", () => {
+    // Older callers pass no paging parameters and expect the full list.
+    cy.request(API).then((res) => {
+      expect(res.status).to.eq(200);
+      expect(res.body).to.be.an("array");
+      expect(res.body.length).to.be.greaterThan(5);
+    });
+  });
+
+  it("should narrow the result set with a search term", () => {
+    cy.request(`${API}?pageSize=20&q=Diebe`).then((res) => {
+      expect(res.body.total).to.be.greaterThan(0);
+      expect(res.body.books.length).to.eq(res.body.total);
+      res.body.books.forEach((b: { title: string }) => {
+        expect(b.title).to.contain("Diebe");
+      });
+    });
+  });
+
+  it("should page the public catalogue without a session", () => {
+    cy.clearCookies();
+    cy.request(`${PUBLIC_API}?pageSize=3&page=1`).then((res) => {
+      expect(res.status).to.eq(200);
+      expect(res.body.books).to.have.length(3);
+      expect(res.body.pageSize).to.eq(3);
+      expect(res.body.total).to.be.greaterThan(3);
+    });
+  });
+
+  it("should still answer the public catalogue with a plain array by default", () => {
+    cy.clearCookies();
+    cy.request(PUBLIC_API).then((res) => {
+      expect(res.body).to.be.an("array");
+      expect(res.body.length).to.be.greaterThan(3);
+    });
+  });
+
+  it("should render the book list page and its search field", () => {
+    cy.visit("http://localhost:3000/book");
+    cy.get("[data-cy=rental_input_searchbook]").should("be.visible");
+    cy.contains("Herr der Diebe").should("be.visible");
+  });
+});

--- a/doc/mkdocs/docs/development/api-reference.md
+++ b/doc/mkdocs/docs/development/api-reference.md
@@ -16,6 +16,33 @@ http://localhost:3000/api
 GET /api/book
 ```
 
+Ohne Parameter liefert der Endpunkt weiterhin die vollständige Liste als Array, damit bestehende Aufrufe unverändert funktionieren.
+
+### Bücher seitenweise abrufen
+
+```http
+GET /api/book?pageSize=20&page=2&q=Ende
+```
+
+Sobald `pageSize` gesetzt ist, wird serverseitig geblättert und gesucht. `page` beginnt bei 1 und ist optional, `q` durchsucht Titel, Untertitel, Autor, ISBN und Schlagwörter. Die Antwort ist dann kein Array mehr, sondern ein Objekt:
+
+```json
+{
+  "books": [],
+  "total": 1234,
+  "page": 2,
+  "pageSize": 20
+}
+```
+
+`total` zählt alle Treffer im Bestand, nicht nur die zurückgelieferte Seite. Damit kann der Client die Seitenzahl berechnen, ohne den gesamten Katalog zu laden.
+
+Der öffentliche Katalog versteht dieselben Parameter:
+
+```http
+GET /api/public/books?pageSize=20&page=2&q=Ende
+```
+
 ### Einzelnes Buch
 
 ```http

--- a/entities/audit.ts
+++ b/entities/audit.ts
@@ -105,7 +105,9 @@ export async function getAllAudit(
 }
 
 export async function addAudit(
-  client: PrismaClient,
+  // Accepts a transaction client too, so callers can write the audit entry
+  // atomically with the change it describes.
+  client: PrismaClient | Prisma.TransactionClient,
   eventType: string,
   eventContent: string,
   // Schema has bookid/userid as Int? (nullable) – use undefined, not 0,

--- a/entities/book.ts
+++ b/entities/book.ts
@@ -11,6 +11,110 @@ import { PublicBookType } from "./PublicBookType";
 import { getUser } from "./user";
 
 const rentalConfig = getRentalConfig();
+
+const publicBookSelect = {
+  id: true,
+  title: true,
+  author: true,
+  isbn: true,
+  topics: true,
+  rentalStatus: true,
+} satisfies Prisma.BookSelect;
+
+function toPublicBook(b: {
+  id: number;
+  title: string;
+  author: string;
+  isbn: string | null;
+  topics: string | null;
+  rentalStatus: string;
+}): PublicBookType {
+  return {
+    id: b.id,
+    title: b.title,
+    author: b.author,
+    isbn: b.isbn,
+    topics: b.topics,
+    rentalStatus: b.rentalStatus,
+    // Cover is served by /api/images/[id]; auth-excluded in middleware.ts
+    coverUrl: `/api/images/${b.id}`,
+  };
+}
+
+export type PagedPublicBooks = {
+  books: PublicBookType[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export function getPublicBookWhere(
+  query: string,
+): Prisma.BookWhereInput | undefined {
+  const q = query.trim();
+  if (!q) return undefined;
+
+  const or: Prisma.BookWhereInput[] = [
+    { title: { contains: q } },
+    { author: { contains: q } },
+    { isbn: { contains: q } },
+    { topics: { contains: q } },
+  ];
+
+  const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
+  if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
+    or.unshift({ id: numericId });
+  }
+
+  return { OR: or };
+}
+
+export async function getCopyCountsByIsbn(
+  client: PrismaClient,
+  books: Array<{ isbn?: string | null }>,
+  where: Prisma.BookWhereInput | undefined,
+): Promise<Map<string, number>> {
+  const rawIsbns = Array.from(
+    new Set(
+      books
+        .map((book) => book.isbn)
+        .filter((isbn): isbn is string => Boolean(isbn?.trim())),
+    ),
+  );
+
+  if (rawIsbns.length === 0) return new Map();
+
+  const counts = await client.book.groupBy({
+    by: ["isbn"],
+    where: {
+      AND: [
+        ...(where ? [where] : []),
+        {
+          isbn: {
+            in: rawIsbns,
+          },
+        },
+      ],
+    },
+    _count: {
+      _all: true,
+    },
+  });
+
+  const countByTrimmedIsbn = new Map<string, number>();
+
+  for (const count of counts) {
+    const isbn = count.isbn?.trim();
+    if (!isbn) continue;
+    countByTrimmedIsbn.set(
+      isbn,
+      (countByTrimmedIsbn.get(isbn) ?? 0) + count._count._all,
+    );
+  }
+
+  return countByTrimmedIsbn;
+}
+
 export async function getBook(client: PrismaClient, id: number) {
   return await client.book.findUnique({ where: { id } });
 }
@@ -72,27 +176,11 @@ export async function getPublicBooks(
 ): Promise<PublicBookType[]> {
   try {
     const rawBooks = await client.book.findMany({
-      select: {
-        id: true,
-        title: true,
-        author: true,
-        isbn: true,
-        topics: true,
-        rentalStatus: true,
-      },
+      select: publicBookSelect,
       orderBy: { title: "asc" },
     });
 
-    return rawBooks.map((b) => ({
-      id: b.id,
-      title: b.title,
-      author: b.author,
-      isbn: b.isbn,
-      topics: b.topics,
-      rentalStatus: b.rentalStatus,
-      // Cover is served by /api/images/[id]; auth-excluded in middleware.ts
-      coverUrl: `/api/images/${b.id}`,
-    }));
+    return rawBooks.map(toPublicBook);
   } catch (e) {
     if (
       e instanceof Prisma.PrismaClientKnownRequestError ||
@@ -105,6 +193,52 @@ export async function getPublicBooks(
           error: e instanceof Error ? e.message : String(e),
         },
         "Error getting public books",
+      );
+    }
+    throw e;
+  }
+}
+
+export async function getPagedPublicBooks(
+  client: PrismaClient,
+  {
+    page,
+    pageSize,
+    query = "",
+  }: { page: number; pageSize: number; query?: string },
+): Promise<PagedPublicBooks> {
+  const where = getPublicBookWhere(query);
+
+  try {
+    const [rawBooks, total] = await Promise.all([
+      client.book.findMany({
+        select: publicBookSelect,
+        where,
+        orderBy: { title: "asc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      client.book.count({ where }),
+    ]);
+
+    return {
+      books: rawBooks.map(toPublicBook),
+      total,
+      page,
+      pageSize,
+    };
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError ||
+      e instanceof Prisma.PrismaClientValidationError
+    ) {
+      errorLogger.error(
+        {
+          event: LogEvents.DB_ERROR,
+          operation: "getPagedPublicBooks",
+          error: e instanceof Error ? e.message : String(e),
+        },
+        "Error getting paged public books",
       );
     }
     throw e;

--- a/entities/book.ts
+++ b/entities/book.ts
@@ -2,6 +2,7 @@ import { BookType } from "@/entities/BookType";
 import { getRentalConfig } from "@/lib/config/rentalConfig";
 import { LogEvents } from "@/lib/logEvents";
 import { businessLogger, errorLogger } from "@/lib/logger";
+import { convertDateToDayString } from "@/lib/utils/dateutils";
 import { Prisma, PrismaClient } from "@prisma/client";
 import dayjs from "dayjs";
 import fs from "fs/promises";
@@ -48,25 +49,66 @@ export type PagedPublicBooks = {
   pageSize: number;
 };
 
-export function getPublicBookWhere(
+type SearchableBookField = "title" | "author" | "subtitle" | "isbn" | "topics";
+
+function capitalizeFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * SQLite's LIKE only case-folds ASCII, so `contains: "möwe"` would not match
+ * "Möwe" (and Prisma's SQLite connector has no `mode: "insensitive"`).
+ * Matching the term as typed, lowercased, and with a capitalized first letter
+ * covers the common casings without a custom collation. Mixed-case matches in
+ * the middle of a word (e.g. "McDonald" for query "mcdonald") still slip
+ * through — accepted limitation.
+ */
+function termVariants(term: string): string[] {
+  const lower = term.toLowerCase();
+  return Array.from(new Set([term, lower, capitalizeFirst(lower)]));
+}
+
+function buildBookWhere(
   query: string,
+  fields: SearchableBookField[],
 ): Prisma.BookWhereInput | undefined {
   const q = query.trim();
   if (!q) return undefined;
 
-  const or: Prisma.BookWhereInput[] = [
-    { title: { contains: q } },
-    { author: { contains: q } },
-    { isbn: { contains: q } },
-    { topics: { contains: q } },
-  ];
+  // AND across whitespace-separated terms, OR across fields per term, so
+  // "Harry Rowling" finds a book whose title contains "Harry" and whose
+  // author contains "Rowling".
+  const perTerm: Prisma.BookWhereInput[] = q.split(/\s+/).map((term) => ({
+    OR: fields.flatMap((field) =>
+      termVariants(term).map((variant) => ({
+        [field]: { contains: variant },
+      })),
+    ),
+  }));
 
   const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
   if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
-    or.unshift({ id: numericId });
+    return { OR: [{ id: numericId }, { AND: perTerm }] };
   }
 
-  return { OR: or };
+  return { AND: perTerm };
+}
+
+export function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
+  return buildBookWhere(query, [
+    "title",
+    "author",
+    "subtitle",
+    "isbn",
+    "topics",
+  ]);
+}
+
+export function getPublicBookWhere(
+  query: string,
+): Prisma.BookWhereInput | undefined {
+  // No subtitle: the public catalog's select doesn't expose it.
+  return buildBookWhere(query, ["title", "author", "isbn", "topics"]);
 }
 
 export async function getCopyCountsByIsbn(
@@ -113,6 +155,106 @@ export async function getCopyCountsByIsbn(
   }
 
   return countByTrimmedIsbn;
+}
+
+// Fields the (authenticated) book list needs — a strict subset of the full
+// Book model so list queries stay lean. Shared by /api/book and the book
+// page's getServerSideProps so SSR and client revalidation return identical
+// shapes.
+export const listBookSelect = {
+  createdAt: true,
+  updatedAt: true,
+  id: true,
+  rentalStatus: true,
+  rentedDate: true,
+  dueDate: true,
+  renewalCount: true,
+  title: true,
+  subtitle: true,
+  author: true,
+  topics: true,
+  isbn: true,
+  userId: true,
+} satisfies Prisma.BookSelect;
+
+export type ListBookType = BookType & {
+  searchableTopics: string[];
+  copyCount?: number;
+};
+
+export type PagedBooks = {
+  books: ListBookType[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export function toListBook(
+  book: Prisma.BookGetPayload<{ select: typeof listBookSelect }>,
+  copyCountsByIsbn: Map<string, number> = new Map(),
+): ListBookType {
+  const isbn = book.isbn?.trim();
+
+  return {
+    ...book,
+    createdAt: convertDateToDayString(book.createdAt) as any,
+    updatedAt: convertDateToDayString(book.updatedAt) as any,
+    rentedDate: book.rentedDate ? convertDateToDayString(book.rentedDate) : "",
+    dueDate: book.dueDate ? convertDateToDayString(book.dueDate) : "",
+    subtitle: book.subtitle ?? undefined,
+    topics: book.topics ?? undefined,
+    isbn: book.isbn ?? undefined,
+    userId: book.userId ?? undefined,
+    copyCount: isbn ? copyCountsByIsbn.get(isbn) : undefined,
+    searchableTopics: book.topics ? book.topics.split(";") : [],
+  };
+}
+
+export async function getPagedBooks(
+  client: PrismaClient,
+  {
+    page,
+    pageSize,
+    query = "",
+  }: { page: number; pageSize: number; query?: string },
+): Promise<PagedBooks> {
+  const where = getBookWhere(query);
+
+  try {
+    const [rawBooks, total] = await Promise.all([
+      client.book.findMany({
+        select: listBookSelect,
+        where,
+        orderBy: [{ id: "desc" }],
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      client.book.count({ where }),
+    ]);
+    const copyCountsByIsbn = await getCopyCountsByIsbn(client, rawBooks, where);
+
+    return {
+      books: rawBooks.map((book) => toListBook(book, copyCountsByIsbn)),
+      total,
+      page,
+      pageSize,
+    };
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError ||
+      e instanceof Prisma.PrismaClientValidationError
+    ) {
+      errorLogger.error(
+        {
+          event: LogEvents.DB_ERROR,
+          operation: "getPagedBooks",
+          error: e instanceof Error ? e.message : String(e),
+        },
+        "Error getting paged books",
+      );
+    }
+    throw e;
+  }
 }
 
 export async function getBook(client: PrismaClient, id: number) {
@@ -411,61 +553,73 @@ export async function updateBook(
       id,
     );
 
-    const transaction: any[] = [];
+    // Invariant: a book may only stay connected to a user while it's
+    // actually "rented". If the status is being explicitly changed to
+    // anything else (lost, broken, available, ...), sever the connection
+    // too - otherwise the book keeps a dangling userId and gets
+    // cascade-deleted if that user is later removed, even though it's no
+    // longer their book. A partial update that omits rentalStatus must NOT
+    // sever an active rental, hence the undefined check.
+    const severConnection =
+      bookData.rentalStatus !== undefined && bookData.rentalStatus !== "rented";
 
-    transaction.push(
-      client.book.update({
-        where: {
-          id,
-        },
-        data: { ...bookData },
-      }),
+    // Interactive transaction: the userId read, the disconnect, the book
+    // update, and the audit entry commit (or roll back) together, so the
+    // audit trail can never claim a disconnect that didn't happen.
+    const { updatedBook, disconnectedUserId } = await client.$transaction(
+      async (tx) => {
+        let disconnectedUserId: number | null = null;
+
+        if (severConnection) {
+          const current = await tx.book.findUnique({
+            where: { id },
+            select: { userId: true },
+          });
+
+          if (current?.userId) {
+            await tx.user.update({
+              where: { id: current.userId },
+              data: {
+                books: {
+                  disconnect: { id },
+                },
+              },
+            });
+            disconnectedUserId = current.userId;
+
+            await addAudit(
+              tx,
+              "Update book - rental connection severed",
+              `book id ${id}, ${book.title}, status changed to "${bookData.rentalStatus}", disconnected from user id ${current.userId}`,
+              id,
+              current.userId,
+            );
+          }
+        }
+
+        const updatedBook = await tx.book.update({
+          where: {
+            id,
+          },
+          data: { ...bookData },
+        });
+
+        return { updatedBook, disconnectedUserId };
+      },
     );
 
-    // Invariant: a book may only stay connected to a user while it's
-    // actually "rented". If the status is being changed to anything else
-    // (lost, broken, available, ...), sever the connection here too -
-    // otherwise the book keeps a dangling userId and gets cascade-deleted
-    // if that user is later removed, even though it's no longer their book.
-    if (bookData.rentalStatus !== "rented") {
-      const current = await client.book.findUnique({
-        where: { id },
-        select: { userId: true },
-      });
-
-      if (current?.userId) {
-        transaction.push(
-          client.user.update({
-            where: { id: current.userId },
-            data: {
-              books: {
-                disconnect: { id },
-              },
-            },
-          }),
-        );
-
-        await addAudit(
-          client,
-          "Update book - rental connection severed",
-          `book id ${id}, ${book.title}, status changed to "${bookData.rentalStatus}", disconnected from user id ${current.userId}`,
-          id,
-          current.userId,
-        );
-
-        businessLogger.info(
-          {
-            event: LogEvents.BOOK_UPDATED,
-            bookId: id,
-            userId: current.userId,
-            newRentalStatus: bookData.rentalStatus,
-          },
-          "Book status changed away from 'rented' - severed user connection",
-        );
-      }
+    if (disconnectedUserId !== null) {
+      businessLogger.info(
+        {
+          event: LogEvents.BOOK_UPDATED,
+          bookId: id,
+          userId: disconnectedUserId,
+          newRentalStatus: bookData.rentalStatus,
+        },
+        "Book status changed away from 'rented' - severed user connection",
+      );
     }
 
-    const [updatedBook] = await client.$transaction(transaction);
     return updatedBook;
   } catch (e) {
     if (

--- a/entities/book.ts
+++ b/entities/book.ts
@@ -1,5 +1,7 @@
 import { BookType } from "@/entities/BookType";
 import { getRentalConfig } from "@/lib/config/rentalConfig";
+import { LOCALE } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n/types";
 import { LogEvents } from "@/lib/logEvents";
 import { businessLogger, errorLogger } from "@/lib/logger";
 import { convertDateToDayString } from "@/lib/utils/dateutils";
@@ -55,6 +57,52 @@ function capitalizeFirst(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+// Inflection endings per deployment locale, longest first so "Deutschen"
+// strips "en" rather than "n". Keyed by Locale so wiring a new locale into
+// the i18n layer forces a decision here too.
+const STEM_SUFFIXES_BY_LOCALE: Record<Locale, string[]> = {
+  de: ["en", "er", "es", "em", "e", "n", "s"],
+  // "ies" covers y-plurals by prefix: "stories" → "stor" matches "story".
+  en: ["ies", "ing", "ed", "es", "er", "e", "s"],
+};
+const STEM_SUFFIXES =
+  STEM_SUFFIXES_BY_LOCALE[LOCALE] ?? STEM_SUFFIXES_BY_LOCALE.de;
+const MIN_STEM_LENGTH = 4;
+
+/**
+ * Cheap query-side stemming: strip one inflection suffix when the remaining
+ * stem keeps at least MIN_STEM_LENGTH characters. Because matching is
+ * substring-based, searching for the stem covers every longer inflected form
+ * in the data ("Deutsche" → "Deutsch" also finds "Deutschen" and
+ * "Deutschland"; "Geschichten" → "Geschicht" also finds "Geschichte").
+ * Umlaut plurals ("Bücher" vs "Buch") are out of scope. The minimum length
+ * keeps short names intact ("Hans" stays "Hans" instead of matching every
+ * "Han…"). Stripping only ever broadens a match (the stem is a prefix of
+ * the term), so an imperfectly fitting suffix list costs precision on rare
+ * queries, never correctness.
+ *
+ * Deliberately NOT a real stemmer (Snowball/Porter via a library): those
+ * normalize both the indexed text and the query symmetrically, but here the
+ * data sits unstemmed in SQLite and matching is `contains`, so the output
+ * must stay a literal prefix of the inflected word. Library stemmers break
+ * that invariant (Snowball German de-umlauts: "Gebäude" → "gebaud"; Porter:
+ * "stories" → "stori", not a substring of "story") and would silently LOSE
+ * results if applied to the query alone. A real stemmer only becomes
+ * appropriate once stemming moves to index time (a stemmed shadow column or
+ * SQLite FTS5) and is applied to both sides.
+ */
+function stemTerm(term: string): string | null {
+  for (const suffix of STEM_SUFFIXES) {
+    if (
+      term.length - suffix.length >= MIN_STEM_LENGTH &&
+      term.toLowerCase().endsWith(suffix)
+    ) {
+      return term.slice(0, -suffix.length);
+    }
+  }
+  return null;
+}
+
 /**
  * SQLite's LIKE only case-folds ASCII, so `contains: "möwe"` would not match
  * "Möwe" (and Prisma's SQLite connector has no `mode: "insensitive"`).
@@ -62,10 +110,14 @@ function capitalizeFirst(s: string): string {
  * covers the common casings without a custom collation. Mixed-case matches in
  * the middle of a word (e.g. "McDonald" for query "mcdonald") still slip
  * through — accepted limitation.
+ *
+ * When the term carries an inflection suffix, the variants are built from its
+ * stem instead; the stem is a prefix of the term, so it matches strictly more.
  */
 function termVariants(term: string): string[] {
-  const lower = term.toLowerCase();
-  return Array.from(new Set([term, lower, capitalizeFirst(lower)]));
+  const base = stemTerm(term) ?? term;
+  const lower = base.toLowerCase();
+  return Array.from(new Set([base, lower, capitalizeFirst(lower)]));
 }
 
 function buildBookWhere(

--- a/entities/book.ts
+++ b/entities/book.ts
@@ -138,12 +138,16 @@ function buildBookWhere(
     ),
   }));
 
-  const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
-  if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
-    return { OR: [{ id: numericId }, { AND: perTerm }] };
-  }
-
   return { AND: perTerm };
+}
+
+/** The book id a purely numeric query denotes, or null if it isn't one. */
+function queryAsBookId(query: string): number | null {
+  const q = query.trim();
+  if (!/^\d+$/.test(q)) return null;
+  // A scanner may pad the number with leading zeros.
+  const id = parseInt(q.replace(/^0+/, "") || q, 10);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
 }
 
 export function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
@@ -154,6 +158,30 @@ export function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
     "isbn",
     "topics",
   ]);
+}
+
+/**
+ * Search predicate for a paged query.
+ *
+ * A purely numeric query is nearly always a Mediennummer off a barcode
+ * scanner, so when a book carries that id it is the only sensible result and
+ * anything else is noise. When no book has it the digits are meant as text
+ * (a year, a number in a title) and the ordinary field search applies. The id
+ * lookup is a primary-key hit, so this costs nothing measurable.
+ */
+async function resolveWhere(
+  client: PrismaClient,
+  query: string,
+  textWhere: Prisma.BookWhereInput | undefined,
+): Promise<Prisma.BookWhereInput | undefined> {
+  const id = queryAsBookId(query);
+  if (id === null) return textWhere;
+
+  const exists = await client.book.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  return exists ? { id } : textWhere;
 }
 
 export function getPublicBookWhere(
@@ -246,13 +274,7 @@ export function toListBook(
   copyCountsByIsbn: Map<string, number> = new Map(),
 ): ListBookType {
   const trimmedIsbn = book.isbn?.trim();
-  const {
-    subtitle,
-    topics,
-    isbn,
-    userId,
-    ...rest
-  } = book;
+  const { subtitle, topics, isbn, userId, ...rest } = book;
 
   const listBook: ListBookType = {
     ...rest,
@@ -286,7 +308,7 @@ export async function getPagedBooks(
     query = "",
   }: { page: number; pageSize: number; query?: string },
 ): Promise<PagedBooks> {
-  const where = getBookWhere(query);
+  const where = await resolveWhere(client, query, getBookWhere(query));
 
   try {
     const [rawBooks, total] = await Promise.all([
@@ -417,7 +439,7 @@ export async function getPagedPublicBooks(
     query = "",
   }: { page: number; pageSize: number; query?: string },
 ): Promise<PagedPublicBooks> {
-  const where = getPublicBookWhere(query);
+  const where = await resolveWhere(client, query, getPublicBookWhere(query));
 
   try {
     const [rawBooks, total] = await Promise.all([

--- a/entities/book.ts
+++ b/entities/book.ts
@@ -245,21 +245,37 @@ export function toListBook(
   book: Prisma.BookGetPayload<{ select: typeof listBookSelect }>,
   copyCountsByIsbn: Map<string, number> = new Map(),
 ): ListBookType {
-  const isbn = book.isbn?.trim();
+  const trimmedIsbn = book.isbn?.trim();
+  const {
+    subtitle,
+    topics,
+    isbn,
+    userId,
+    ...rest
+  } = book;
 
-  return {
-    ...book,
+  const listBook: ListBookType = {
+    ...rest,
     createdAt: convertDateToDayString(book.createdAt) as any,
     updatedAt: convertDateToDayString(book.updatedAt) as any,
     rentedDate: book.rentedDate ? convertDateToDayString(book.rentedDate) : "",
     dueDate: book.dueDate ? convertDateToDayString(book.dueDate) : "",
-    subtitle: book.subtitle ?? undefined,
-    topics: book.topics ?? undefined,
-    isbn: book.isbn ?? undefined,
-    userId: book.userId ?? undefined,
-    copyCount: isbn ? copyCountsByIsbn.get(isbn) : undefined,
-    searchableTopics: book.topics ? book.topics.split(";") : [],
+    searchableTopics: topics ? topics.split(";") : [],
   };
+
+  // Optional fields are left out entirely rather than set to undefined. Both
+  // look the same once the API route serialises them to JSON, but
+  // getServerSideProps validates its props and rejects an explicit undefined,
+  // which made /book fail to render as soon as one book had no subtitle.
+  if (subtitle !== null) listBook.subtitle = subtitle;
+  if (topics !== null) listBook.topics = topics;
+  if (isbn !== null) listBook.isbn = isbn;
+  if (userId !== null) listBook.userId = userId;
+
+  const copyCount = trimmedIsbn ? copyCountsByIsbn.get(trimmedIsbn) : undefined;
+  if (copyCount !== undefined) listBook.copyCount = copyCount;
+
+  return listBook;
 }
 
 export async function getPagedBooks(

--- a/lib/i18n/de.ts
+++ b/lib/i18n/de.ts
@@ -1248,6 +1248,9 @@ export const de = {
     fieldYear: "Jahr",
     fieldPages: "Seiten",
     fieldAge: "Altersempfehlung",
+    // Rendered when only one bound of the age range is set.
+    ageFrom: "ab {min}",
+    ageUpTo: "bis {max}",
     fieldIsbn: "ISBN",
     notFound: "Buch nicht gefunden.",
   },

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -1157,6 +1157,8 @@ export const en: Dictionary = {
     fieldYear: "Year",
     fieldPages: "Pages",
     fieldAge: "Age recommendation",
+    ageFrom: "from {min}",
+    ageUpTo: "up to {max}",
     fieldIsbn: "ISBN",
     notFound: "Book not found.",
   },

--- a/lib/i18n/es.ts
+++ b/lib/i18n/es.ts
@@ -1180,6 +1180,8 @@ export const es: Dictionary = {
     fieldYear: "Año",
     fieldPages: "Páginas",
     fieldAge: "Edad recomendada",
+    ageFrom: "a partir de {min}",
+    ageUpTo: "hasta {max}",
     fieldIsbn: "ISBN",
     notFound: "Libro no encontrado.",
   },

--- a/lib/loginImage.ts
+++ b/lib/loginImage.ts
@@ -13,5 +13,20 @@
 export function resolveLoginImage(): string | null {
   const raw = process.env.LOGIN_IMAGE?.trim();
   if (!raw) return null;
-  return raw.startsWith("/") ? raw : `/${raw}`;
+  const rooted = raw.startsWith("/") ? raw : `/${raw}`;
+  // Percent-encode each path segment: browsers request the encoded form
+  // ("/schule login.jpg" arrives as "/schule%20login.jpg" in
+  // req.nextUrl.pathname), and CSS url(...) can't contain raw spaces either.
+  // Decode first so an already-encoded value isn't double-encoded.
+  return rooted
+    .split("/")
+    .map((segment) => {
+      try {
+        return encodeURIComponent(decodeURIComponent(segment));
+      } catch {
+        // Malformed escape sequence in the segment (e.g. a literal "%")
+        return encodeURIComponent(segment);
+      }
+    })
+    .join("/");
 }

--- a/lib/loginImage.ts
+++ b/lib/loginImage.ts
@@ -13,20 +13,5 @@
 export function resolveLoginImage(): string | null {
   const raw = process.env.LOGIN_IMAGE?.trim();
   if (!raw) return null;
-  const rooted = raw.startsWith("/") ? raw : `/${raw}`;
-  // Percent-encode each path segment: browsers request the encoded form
-  // ("/schule login.jpg" arrives as "/schule%20login.jpg" in
-  // req.nextUrl.pathname), and CSS url(...) can't contain raw spaces either.
-  // Decode first so an already-encoded value isn't double-encoded.
-  return rooted
-    .split("/")
-    .map((segment) => {
-      try {
-        return encodeURIComponent(decodeURIComponent(segment));
-      } catch {
-        // Malformed escape sequence in the segment (e.g. a literal "%")
-        return encodeURIComponent(segment);
-      }
-    })
-    .join("/");
+  return raw.startsWith("/") ? raw : `/${raw}`;
 }

--- a/lib/utils/queryParams.ts
+++ b/lib/utils/queryParams.ts
@@ -1,0 +1,17 @@
+/**
+ * Helpers for reading Next.js API route query parameters, which arrive as
+ * `string | string[] | undefined`.
+ */
+
+export function getSingleQueryValue(
+  value: string | string[] | undefined,
+): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+export function getPositiveInt(
+  value: string | string[] | undefined,
+): number | null {
+  const parsed = parseInt(getSingleQueryValue(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}

--- a/pages/api/book.ts
+++ b/pages/api/book.ts
@@ -1,88 +1,14 @@
 import { BookType } from "@/entities/BookType";
-import { addBook, getAllBooks, getCopyCountsByIsbn } from "@/entities/book";
+import { addBook, getAllBooks, getPagedBooks, PagedBooks } from "@/entities/book";
 import { prisma } from "@/entities/db";
 import { LogEvents } from "@/lib/logEvents";
 import { businessLogger, errorLogger } from "@/lib/logger";
-import { convertDateToDayString } from "@/lib/utils/dateutils";
-import { Prisma } from "@prisma/client";
+import { getPositiveInt, getSingleQueryValue } from "@/lib/utils/queryParams";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 type Data = {
   result: string;
 };
-
-type PagedBooks = {
-  books: Array<BookType & { searchableTopics: string[]; copyCount?: number }>;
-  total: number;
-  page: number;
-  pageSize: number;
-};
-
-const listBookSelect = {
-  createdAt: true,
-  updatedAt: true,
-  id: true,
-  rentalStatus: true,
-  rentedDate: true,
-  dueDate: true,
-  renewalCount: true,
-  title: true,
-  subtitle: true,
-  author: true,
-  topics: true,
-  isbn: true,
-  userId: true,
-} satisfies Prisma.BookSelect;
-
-function getSingleQueryValue(value: string | string[] | undefined): string {
-  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
-}
-
-function getPositiveInt(value: string | string[] | undefined): number | null {
-  const parsed = parseInt(getSingleQueryValue(value), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
-  const q = query.trim();
-  if (!q) return undefined;
-
-  const or: Prisma.BookWhereInput[] = [
-    { title: { contains: q } },
-    { author: { contains: q } },
-    { subtitle: { contains: q } },
-    { isbn: { contains: q } },
-    { topics: { contains: q } },
-  ];
-
-  const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
-  if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
-    or.unshift({ id: numericId });
-  }
-
-  return { OR: or };
-}
-
-function toListBook(
-  book: Prisma.BookGetPayload<{ select: typeof listBookSelect }>,
-  copyCountsByIsbn: Map<string, number> = new Map(),
-): BookType & { searchableTopics: string[]; copyCount?: number } {
-  const isbn = book.isbn?.trim();
-
-  return {
-    ...book,
-    createdAt: convertDateToDayString(book.createdAt) as any,
-    updatedAt: convertDateToDayString(book.updatedAt) as any,
-    rentedDate: book.rentedDate ? convertDateToDayString(book.rentedDate) : "",
-    dueDate: book.dueDate ? convertDateToDayString(book.dueDate) : "",
-    subtitle: book.subtitle ?? undefined,
-    topics: book.topics ?? undefined,
-    isbn: book.isbn ?? undefined,
-    userId: book.userId ?? undefined,
-    copyCount: isbn ? copyCountsByIsbn.get(isbn) : undefined,
-    searchableTopics: book.topics ? book.topics.split(";") : [],
-  };
-}
 
 export default async function handler(
   req: NextApiRequest,
@@ -127,29 +53,12 @@ export default async function handler(
         const q = getSingleQueryValue(req.query.q);
 
         if (pageSize) {
-          const where = getBookWhere(q);
-          const [rawBooks, total] = await Promise.all([
-            prisma.book.findMany({
-              select: listBookSelect,
-              where,
-              orderBy: [{ id: "desc" }],
-              skip: (page - 1) * pageSize,
-              take: pageSize,
-            }),
-            prisma.book.count({ where }),
-          ]);
-          const copyCountsByIsbn = await getCopyCountsByIsbn(
-            prisma,
-            rawBooks,
-            where,
-          );
-
-          return res.status(200).json({
-            books: rawBooks.map((book) => toListBook(book, copyCountsByIsbn)),
-            total,
+          const result = await getPagedBooks(prisma, {
             page,
             pageSize,
+            query: q,
           });
+          return res.status(200).json(result);
         }
 
         const books = (await getAllBooks(prisma)) as Array<BookType>;

--- a/pages/api/book.ts
+++ b/pages/api/book.ts
@@ -1,17 +1,92 @@
 import { BookType } from "@/entities/BookType";
-import { addBook, getAllBooks } from "@/entities/book";
+import { addBook, getAllBooks, getCopyCountsByIsbn } from "@/entities/book";
 import { prisma } from "@/entities/db";
 import { LogEvents } from "@/lib/logEvents";
 import { businessLogger, errorLogger } from "@/lib/logger";
+import { convertDateToDayString } from "@/lib/utils/dateutils";
+import { Prisma } from "@prisma/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 type Data = {
   result: string;
 };
 
+type PagedBooks = {
+  books: Array<BookType & { searchableTopics: string[]; copyCount?: number }>;
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+const listBookSelect = {
+  createdAt: true,
+  updatedAt: true,
+  id: true,
+  rentalStatus: true,
+  rentedDate: true,
+  dueDate: true,
+  renewalCount: true,
+  title: true,
+  subtitle: true,
+  author: true,
+  topics: true,
+  isbn: true,
+  userId: true,
+} satisfies Prisma.BookSelect;
+
+function getSingleQueryValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function getPositiveInt(value: string | string[] | undefined): number | null {
+  const parsed = parseInt(getSingleQueryValue(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
+  const q = query.trim();
+  if (!q) return undefined;
+
+  const or: Prisma.BookWhereInput[] = [
+    { title: { contains: q } },
+    { author: { contains: q } },
+    { subtitle: { contains: q } },
+    { isbn: { contains: q } },
+    { topics: { contains: q } },
+  ];
+
+  const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
+  if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
+    or.unshift({ id: numericId });
+  }
+
+  return { OR: or };
+}
+
+function toListBook(
+  book: Prisma.BookGetPayload<{ select: typeof listBookSelect }>,
+  copyCountsByIsbn: Map<string, number> = new Map(),
+): BookType & { searchableTopics: string[]; copyCount?: number } {
+  const isbn = book.isbn?.trim();
+
+  return {
+    ...book,
+    createdAt: convertDateToDayString(book.createdAt) as any,
+    updatedAt: convertDateToDayString(book.updatedAt) as any,
+    rentedDate: book.rentedDate ? convertDateToDayString(book.rentedDate) : "",
+    dueDate: book.dueDate ? convertDateToDayString(book.dueDate) : "",
+    subtitle: book.subtitle ?? undefined,
+    topics: book.topics ?? undefined,
+    isbn: book.isbn ?? undefined,
+    userId: book.userId ?? undefined,
+    copyCount: isbn ? copyCountsByIsbn.get(isbn) : undefined,
+    searchableTopics: book.topics ? book.topics.split(";") : [],
+  };
+}
+
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Data | BookType | Array<BookType>>
+  res: NextApiResponse<Data | BookType | Array<BookType> | PagedBooks>,
 ) {
   switch (req.method) {
     case "POST": {
@@ -47,6 +122,36 @@ export default async function handler(
 
     case "GET": {
       try {
+        const pageSize = getPositiveInt(req.query.pageSize);
+        const page = getPositiveInt(req.query.page) ?? 1;
+        const q = getSingleQueryValue(req.query.q);
+
+        if (pageSize) {
+          const where = getBookWhere(q);
+          const [rawBooks, total] = await Promise.all([
+            prisma.book.findMany({
+              select: listBookSelect,
+              where,
+              orderBy: [{ id: "desc" }],
+              skip: (page - 1) * pageSize,
+              take: pageSize,
+            }),
+            prisma.book.count({ where }),
+          ]);
+          const copyCountsByIsbn = await getCopyCountsByIsbn(
+            prisma,
+            rawBooks,
+            where,
+          );
+
+          return res.status(200).json({
+            books: rawBooks.map((book) => toListBook(book, copyCountsByIsbn)),
+            total,
+            page,
+            pageSize,
+          });
+        }
+
         const books = (await getAllBooks(prisma)) as Array<BookType>;
         if (!books) {
           return res.status(400).json({ result: "ERROR: Book not found" });

--- a/pages/api/public/books.ts
+++ b/pages/api/public/books.ts
@@ -1,4 +1,4 @@
-import { getPublicBooks } from "@/entities/book";
+import { getPagedPublicBooks, getPublicBooks, PagedPublicBooks } from "@/entities/book";
 import { prisma, reconnectPrisma } from "@/entities/db";
 import { PublicBookType } from "@/entities/PublicBookType";
 import { LogEvents } from "@/lib/logEvents";
@@ -8,6 +8,15 @@ import type { NextApiRequest, NextApiResponse } from "next";
 type ErrorData = {
   result: string;
 };
+
+function getSingleQueryValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function getPositiveInt(value: string | string[] | undefined): number | null {
+  const parsed = parseInt(getSingleQueryValue(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
 
 /**
  * GET /api/public/books
@@ -20,7 +29,7 @@ type ErrorData = {
  */
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Array<PublicBookType> | ErrorData>,
+  res: NextApiResponse<Array<PublicBookType> | PagedPublicBooks | ErrorData>,
 ) {
   if (req.method !== "GET") {
     res.setHeader("Allow", "GET");
@@ -36,6 +45,31 @@ export default async function handler(
   res.setHeader("Cache-Control", "public, max-age=60, s-maxage=300");
 
   try {
+    const pageSize = getPositiveInt(req.query.pageSize);
+    const page = getPositiveInt(req.query.page) ?? 1;
+    const q = getSingleQueryValue(req.query.q);
+
+    if (pageSize) {
+      const result = await getPagedPublicBooks(prisma, {
+        page,
+        pageSize,
+        query: q,
+      });
+
+      businessLogger.info(
+        {
+          event: LogEvents.BOOK_LIST_FETCHED,
+          count: result.books.length,
+          total: result.total,
+          endpoint: "/api/public/books",
+          paged: true,
+        },
+        "Public book catalog fetched",
+      );
+
+      return res.status(200).json(result);
+    }
+
     const books = await getPublicBooks(prisma);
 
     businessLogger.info(

--- a/pages/api/public/books.ts
+++ b/pages/api/public/books.ts
@@ -3,20 +3,12 @@ import { prisma, reconnectPrisma } from "@/entities/db";
 import { PublicBookType } from "@/entities/PublicBookType";
 import { LogEvents } from "@/lib/logEvents";
 import { businessLogger, errorLogger } from "@/lib/logger";
+import { getPositiveInt, getSingleQueryValue } from "@/lib/utils/queryParams";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 type ErrorData = {
   result: string;
 };
-
-function getSingleQueryValue(value: string | string[] | undefined): string {
-  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
-}
-
-function getPositiveInt(value: string | string[] | undefined): number | null {
-  const parsed = parseInt(getSingleQueryValue(value), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
 
 /**
  * GET /api/public/books

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -9,20 +9,13 @@ import BookSummaryCard from "@/components/book/BookSummaryCard";
 
 import SummaryRowContainer from "@/components/book/SummaryRowContainer";
 import { BookType } from "@/entities/BookType";
-import { getCopyCountsByIsbn } from "@/entities/book";
+import { getPagedBooks, ListBookType, PagedBooks } from "@/entities/book";
 import { prisma, reconnectPrisma } from "@/entities/db";
 import { t } from "@/lib/i18n";
-import { convertDateToDayString } from "@/lib/utils/dateutils";
-import { Prisma } from "@prisma/client";
 import { toast } from "sonner";
 
-interface SearchableBookType extends BookType {
-  searchableTopics: Array<string>;
-  copyCount?: number;
-}
-
 interface BookPropsType {
-  books: Array<SearchableBookType>;
+  books: Array<ListBookType>;
   total: number;
   numberBooksToShow: number;
   maxBooks: number;
@@ -37,70 +30,6 @@ interface DetailCardContainerProps {
   onLoadMore: () => void;
   onReturnBook: (id: number, userId: number) => void;
   onTopicClick: (topic: string) => void;
-}
-
-interface PagedBooksResponse {
-  books: Array<SearchableBookType>;
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
-const listBookSelect = {
-  createdAt: true,
-  updatedAt: true,
-  id: true,
-  rentalStatus: true,
-  rentedDate: true,
-  dueDate: true,
-  renewalCount: true,
-  title: true,
-  subtitle: true,
-  author: true,
-  topics: true,
-  isbn: true,
-  userId: true,
-} satisfies Prisma.BookSelect;
-
-function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
-  const q = query.trim();
-  if (!q) return undefined;
-
-  const or: Prisma.BookWhereInput[] = [
-    { title: { contains: q } },
-    { author: { contains: q } },
-    { subtitle: { contains: q } },
-    { isbn: { contains: q } },
-    { topics: { contains: q } },
-  ];
-
-  const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
-  if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
-    or.unshift({ id: numericId });
-  }
-
-  return { OR: or };
-}
-
-function toSearchableBook(
-  b: Prisma.BookGetPayload<{ select: typeof listBookSelect }>,
-  copyCountsByIsbn: Map<string, number> = new Map(),
-): SearchableBookType {
-  const isbn = b.isbn?.trim();
-
-  return {
-    ...b,
-    createdAt: convertDateToDayString(b.createdAt) as any,
-    updatedAt: convertDateToDayString(b.updatedAt) as any,
-    rentedDate: b.rentedDate ? convertDateToDayString(b.rentedDate) : "",
-    dueDate: b.dueDate ? convertDateToDayString(b.dueDate) : "",
-    subtitle: b.subtitle ?? undefined,
-    topics: b.topics ?? undefined,
-    isbn: b.isbn ?? undefined,
-    userId: b.userId ?? undefined,
-    copyCount: isbn ? copyCountsByIsbn.get(isbn) : undefined,
-    searchableTopics: b.topics ? b.topics.split(";") : [],
-  };
 }
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -189,22 +118,25 @@ export default function Books({
     return `/api/book?${params.toString()}`;
   }, [pageSize, maxBooks, serverSearch]);
 
-  const { data: freshData, mutate } = useSWR<PagedBooksResponse>(
-    requestUrl,
-    fetcher,
-    {
-      fallbackData: {
-        books: initialBooks,
-        total: initialTotal,
-        page: 1,
-        pageSize: numberBooksToShow,
-      },
-      refreshInterval: 0,
-      revalidateOnFocus: true,
-      revalidateOnReconnect: true,
-      dedupingInterval: 60000,
+  const { data: freshData, mutate } = useSWR<PagedBooks>(requestUrl, fetcher, {
+    fallbackData: {
+      books: initialBooks,
+      total: initialTotal,
+      page: 1,
+      pageSize: numberBooksToShow,
     },
-  );
+    // Without this, every key change (new search term, larger pageSize from
+    // "load more") would fall back to the initial unfiltered page-1 data
+    // while the fetch is in flight — a visible flash of wrong results.
+    keepPreviousData: true,
+    refreshInterval: 0,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    // Keep this short (SWR default is 2s): edits happen on other pages, and
+    // a long window would serve a stale cached list when navigating back.
+    // It doesn't help with typing anyway — each search term is its own key.
+    dedupingInterval: 2000,
+  });
 
   const books = freshData?.books || initialBooks;
   const resultCount = freshData?.total ?? initialTotal;
@@ -311,7 +243,6 @@ export default function Books({
       ) : (
         <SummaryRowContainer
           renderedBooks={renderedBooks}
-          pageIndex={renderedBooks.length}
           totalBooks={resultCount}
           maxBooks={maxBooks}
           onLoadMore={handleLoadMore}
@@ -349,26 +280,14 @@ export const getServerSideProps: GetServerSideProps = async (
       : 1000000;
     const initialSearch =
       typeof context.query.q === "string" ? context.query.q : "";
-    const where = getBookWhere(initialSearch);
 
-    const [rawBooks, total] = await Promise.all([
-      prisma.book.findMany({
-        select: listBookSelect,
-        where,
-        orderBy: [{ id: "desc" }],
-        take: numberBooksToShow,
-      }),
-      prisma.book.count({ where }),
-    ]);
-    const copyCountsByIsbn = await getCopyCountsByIsbn(
-      prisma,
-      rawBooks,
-      where,
-    );
-
-    const books = rawBooks.map((book) =>
-      toSearchableBook(book, copyCountsByIsbn),
-    );
+    // Same entity function the API route uses, in-process — SSR and client
+    // revalidation can't drift apart.
+    const { books, total } = await getPagedBooks(prisma, {
+      page: 1,
+      pageSize: numberBooksToShow,
+      query: initialSearch,
+    });
 
     return {
       props: {

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -8,50 +8,120 @@ import BookSearchBar from "@/components/book/BookSearchBar";
 import BookSummaryCard from "@/components/book/BookSummaryCard";
 
 import SummaryRowContainer from "@/components/book/SummaryRowContainer";
-import { getAllBooks } from "@/entities/book";
 import { BookType } from "@/entities/BookType";
+import { getCopyCountsByIsbn } from "@/entities/book";
 import { prisma, reconnectPrisma } from "@/entities/db";
-import { useBookSearch } from "@/hooks/useBookSearch";
 import { t } from "@/lib/i18n";
 import { convertDateToDayString } from "@/lib/utils/dateutils";
+import { Prisma } from "@prisma/client";
 import { toast } from "sonner";
 
 interface SearchableBookType extends BookType {
   searchableTopics: Array<string>;
+  copyCount?: number;
 }
 
 interface BookPropsType {
   books: Array<SearchableBookType>;
+  total: number;
   numberBooksToShow: number;
   maxBooks: number;
+  initialSearch: string;
   _timestamp?: number;
 }
 
 interface DetailCardContainerProps {
   renderedBooks: BookType[];
-  pageIndex: number;
-  numberBooksToShow: number;
+  totalBooks: number;
+  maxBooks: number;
   onLoadMore: () => void;
   onReturnBook: (id: number, userId: number) => void;
   onTopicClick: (topic: string) => void;
+}
+
+interface PagedBooksResponse {
+  books: Array<SearchableBookType>;
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const listBookSelect = {
+  createdAt: true,
+  updatedAt: true,
+  id: true,
+  rentalStatus: true,
+  rentedDate: true,
+  dueDate: true,
+  renewalCount: true,
+  title: true,
+  subtitle: true,
+  author: true,
+  topics: true,
+  isbn: true,
+  userId: true,
+} satisfies Prisma.BookSelect;
+
+function getBookWhere(query: string): Prisma.BookWhereInput | undefined {
+  const q = query.trim();
+  if (!q) return undefined;
+
+  const or: Prisma.BookWhereInput[] = [
+    { title: { contains: q } },
+    { author: { contains: q } },
+    { subtitle: { contains: q } },
+    { isbn: { contains: q } },
+    { topics: { contains: q } },
+  ];
+
+  const numericId = parseInt(q.replace(/^0+/, "") || q, 10);
+  if (/^\d+$/.test(q) && Number.isFinite(numericId)) {
+    or.unshift({ id: numericId });
+  }
+
+  return { OR: or };
+}
+
+function toSearchableBook(
+  b: Prisma.BookGetPayload<{ select: typeof listBookSelect }>,
+  copyCountsByIsbn: Map<string, number> = new Map(),
+): SearchableBookType {
+  const isbn = b.isbn?.trim();
+
+  return {
+    ...b,
+    createdAt: convertDateToDayString(b.createdAt) as any,
+    updatedAt: convertDateToDayString(b.updatedAt) as any,
+    rentedDate: b.rentedDate ? convertDateToDayString(b.rentedDate) : "",
+    dueDate: b.dueDate ? convertDateToDayString(b.dueDate) : "",
+    subtitle: b.subtitle ?? undefined,
+    topics: b.topics ?? undefined,
+    isbn: b.isbn ?? undefined,
+    userId: b.userId ?? undefined,
+    copyCount: isbn ? copyCountsByIsbn.get(isbn) : undefined,
+    searchableTopics: b.topics ? b.topics.split(";") : [],
+  };
 }
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 const DetailCardContainer = memo(function DetailCardContainer({
   renderedBooks,
-  pageIndex,
+  totalBooks,
+  maxBooks,
   onLoadMore,
   onReturnBook,
   onTopicClick,
 }: DetailCardContainerProps) {
+  const visibleLimit = Math.min(totalBooks, maxBooks);
+
   return (
     <div>
       <div
         className="grid gap-3 justify-items-center py-2"
         style={{ gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))" }}
       >
-        {renderedBooks.slice(0, pageIndex).map((b: BookType) => (
+        {renderedBooks.map((b: BookType) => (
           <BookSummaryCard
             key={b.id}
             book={b}
@@ -60,14 +130,14 @@ const DetailCardContainer = memo(function DetailCardContainer({
           />
         ))}
       </div>
-      {renderedBooks.length - pageIndex > 0 && (
+      {visibleLimit - renderedBooks.length > 0 && (
         <div className="flex justify-center mt-4">
           <button
             onClick={onLoadMore}
             className="px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors"
           >
             {t("bookPage.loadMore")}{" "}
-            {Math.max(0, renderedBooks.length - pageIndex)}
+            {Math.max(0, visibleLimit - renderedBooks.length)}
           </button>
         </div>
       )}
@@ -75,62 +145,80 @@ const DetailCardContainer = memo(function DetailCardContainer({
   );
 });
 
-interface SummaryRowContainerProps {
-  renderedBooks: BookType[];
-  pageIndex: number;
-  onLoadMore: () => void;
-  onCopyBook: (book: BookType) => void;
-}
-
 // =============================================================================
 // Page Component
 // =============================================================================
 
 export default function Books({
   books: initialBooks,
+  total: initialTotal,
   numberBooksToShow,
   maxBooks,
+  initialSearch,
 }: BookPropsType) {
   const router = useRouter();
   const { query } = useRouter();
+  const [bookSearchInput, setBookSearchInput] = useState(initialSearch);
+  const [serverSearch, setServerSearch] = useState(initialSearch);
+  const [pageSize, setPageSize] = useState(numberBooksToShow);
+
   useEffect(() => {
     if (typeof query.q === "string" && query.q) {
-      handleInputChange(query.q);
+      setBookSearchInput(query.q);
+      setServerSearch(query.q);
+      setPageSize(numberBooksToShow);
       setDetailView(true);
     }
-  }, [query.q]);
+  }, [query.q, numberBooksToShow]);
 
-  const { data: freshData, mutate } = useSWR("/api/book", fetcher, {
-    fallbackData: { books: initialBooks },
-    refreshInterval: 0,
-    revalidateOnFocus: true,
-    revalidateOnReconnect: true,
-    dedupingInterval: 0,
-  });
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setServerSearch(bookSearchInput);
+      setPageSize(numberBooksToShow);
+    }, 150);
+
+    return () => clearTimeout(id);
+  }, [bookSearchInput, numberBooksToShow]);
+
+  const requestUrl = useMemo(() => {
+    const params = new URLSearchParams({
+      page: "1",
+      pageSize: Math.min(pageSize, maxBooks).toString(),
+    });
+    if (serverSearch.trim()) params.set("q", serverSearch.trim());
+    return `/api/book?${params.toString()}`;
+  }, [pageSize, maxBooks, serverSearch]);
+
+  const { data: freshData, mutate } = useSWR<PagedBooksResponse>(
+    requestUrl,
+    fetcher,
+    {
+      fallbackData: {
+        books: initialBooks,
+        total: initialTotal,
+        page: 1,
+        pageSize: numberBooksToShow,
+      },
+      refreshInterval: 0,
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
+      dedupingInterval: 60000,
+    },
+  );
 
   const books = freshData?.books || initialBooks;
+  const resultCount = freshData?.total ?? initialTotal;
 
   const [detailView, setDetailView] = useState(true);
-  const [pageIndex, setPageIndex] = useState(numberBooksToShow);
-
-  const {
-    renderedBooks: searchedBooks,
-    bookSearchInput,
-    handleInputChange,
-    resultCount,
-  } = useBookSearch(books, {
-    extraSearchableFields: ["searchableTopics"],
-    perPage: maxBooks,
-  });
 
   // Numeric-query priority sort: if the query contains digits, bubble books
   // whose title contains those digits to the top. Runs only when the query
   // or the base results change — no extra state needed.
   const renderedBooks = useMemo(() => {
     const numbersInQuery = bookSearchInput.match(/\d+/g);
-    if (!numbersInQuery) return searchedBooks;
+    if (!numbersInQuery) return books;
 
-    return [...searchedBooks].sort((a, b) => {
+    return [...books].sort((a, b) => {
       const aMatch = numbersInQuery.some((n) =>
         a.title?.toString().includes(n),
       );
@@ -141,16 +229,15 @@ export default function Books({
       if (!aMatch && bMatch) return 1;
       return 0;
     });
-  }, [searchedBooks, bookSearchInput]);
+  }, [books, bookSearchInput]);
 
   // Adapt hook's string-based handler to the event-based signature
   // BookSearchBar expects, and reset pagination on every new search.
   const handleInputChangeEvent = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-      handleInputChange(e.target.value);
-      setPageIndex(numberBooksToShow);
+      setBookSearchInput(e.target.value);
     },
-    [handleInputChange, numberBooksToShow],
+    [],
   );
 
   const handleCreateNewBook = useCallback(() => {
@@ -187,19 +274,19 @@ export default function Books({
 
   const toggleView = useCallback(() => {
     setDetailView((prev) => !prev);
-    setPageIndex(numberBooksToShow);
-  }, [numberBooksToShow]);
+  }, []);
 
   const handleLoadMore = useCallback(() => {
-    setPageIndex((prev) => prev + numberBooksToShow);
-  }, [numberBooksToShow]);
+    setPageSize((prev) => Math.min(prev + numberBooksToShow, maxBooks));
+  }, [numberBooksToShow, maxBooks]);
   const handleTopicClick = useCallback(
     (topic: string) => {
-      handleInputChange(topic);
+      setBookSearchInput(topic);
+      setServerSearch(topic);
       setDetailView(true);
-      setPageIndex(numberBooksToShow);
+      setPageSize(numberBooksToShow);
     },
-    [handleInputChange, numberBooksToShow],
+    [numberBooksToShow],
   );
 
   return (
@@ -215,8 +302,8 @@ export default function Books({
       {detailView ? (
         <DetailCardContainer
           renderedBooks={renderedBooks}
-          pageIndex={pageIndex}
-          numberBooksToShow={numberBooksToShow}
+          totalBooks={resultCount}
+          maxBooks={maxBooks}
           onLoadMore={handleLoadMore}
           onReturnBook={handleReturnBook}
           onTopicClick={handleTopicClick}
@@ -224,7 +311,9 @@ export default function Books({
       ) : (
         <SummaryRowContainer
           renderedBooks={renderedBooks}
-          pageIndex={pageIndex}
+          pageIndex={renderedBooks.length}
+          totalBooks={resultCount}
+          maxBooks={maxBooks}
           onLoadMore={handleLoadMore}
           onCopyBook={handleCopyBook}
         />
@@ -252,36 +341,54 @@ export const getServerSideProps: GetServerSideProps = async (
   context.res.setHeader("Expires", "0");
 
   try {
-    const allBooks = await getAllBooks(prisma);
     const numberBooksToShow = process.env.NUMBER_BOOKS_OVERVIEW
       ? parseInt(process.env.NUMBER_BOOKS_OVERVIEW)
       : 10;
     const maxBooks = process.env.NUMBER_BOOKS_MAX
       ? parseInt(process.env.NUMBER_BOOKS_MAX)
       : 1000000;
+    const initialSearch =
+      typeof context.query.q === "string" ? context.query.q : "";
+    const where = getBookWhere(initialSearch);
 
-    const books = allBooks.map((b) => {
-      const newBook = { ...b } as any;
-      newBook.createdAt = convertDateToDayString(b.createdAt);
-      newBook.updatedAt = convertDateToDayString(b.updatedAt);
-      newBook.rentedDate = b.rentedDate
-        ? convertDateToDayString(b.rentedDate)
-        : "";
-      newBook.dueDate = b.dueDate ? convertDateToDayString(b.dueDate) : "";
-      newBook.searchableTopics = b.topics ? b.topics.split(";") : "";
-      return newBook;
-    });
+    const [rawBooks, total] = await Promise.all([
+      prisma.book.findMany({
+        select: listBookSelect,
+        where,
+        orderBy: [{ id: "desc" }],
+        take: numberBooksToShow,
+      }),
+      prisma.book.count({ where }),
+    ]);
+    const copyCountsByIsbn = await getCopyCountsByIsbn(
+      prisma,
+      rawBooks,
+      where,
+    );
+
+    const books = rawBooks.map((book) =>
+      toSearchableBook(book, copyCountsByIsbn),
+    );
 
     return {
-      props: { books, numberBooksToShow, maxBooks, _timestamp: Date.now() },
+      props: {
+        books,
+        total,
+        numberBooksToShow,
+        maxBooks,
+        initialSearch,
+        _timestamp: Date.now(),
+      },
     };
   } catch (error) {
     console.error("Error fetching books:", error);
     return {
       props: {
         books: [],
+        total: 0,
         numberBooksToShow: 10,
         maxBooks: 1000000,
+        initialSearch: "",
         _timestamp: Date.now(),
       },
     };

--- a/pages/catalog/[id].tsx
+++ b/pages/catalog/[id].tsx
@@ -204,9 +204,9 @@ export default function CatalogDetailPage({ book }: CatalogDetailProps) {
     book.minAge && book.maxAge
       ? `${book.minAge}–${book.maxAge}`
       : book.minAge
-        ? `${book.minAge}`
+        ? t("catalogDetailPage.ageFrom", { min: book.minAge })
         : book.maxAge
-          ? `- ${book.maxAge}`
+          ? t("catalogDetailPage.ageUpTo", { max: book.maxAge })
           : null;
 
   return (

--- a/pages/catalog/index.tsx
+++ b/pages/catalog/index.tsx
@@ -1,15 +1,14 @@
 import BookSearchBar from "@/components/book/BookSearchBar";
 import BookSummaryCard from "@/components/book/BookSummaryCard";
 import Layout from "@/components/layout/Layout";
-import { getPublicBooks } from "@/entities/book";
+import { getPagedPublicBooks } from "@/entities/book";
 import { BookType } from "@/entities/BookType";
 import { prisma } from "@/entities/db";
 import { PublicBookType } from "@/entities/PublicBookType";
-import { useBookSearch } from "@/hooks/useBookSearch";
 import { LogEvents } from "@/lib/logEvents";
 import { errorLogger } from "@/lib/logger";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 
 // =============================================================================
@@ -22,8 +21,17 @@ interface CatalogBookType extends BookType {
 
 interface CatalogPropsType {
   books: Array<CatalogBookType>;
+  total: number;
   numberBooksToShow: number;
   maxBooks: number;
+  initialSearch: string;
+}
+
+interface PagedCatalogResponse {
+  books: Array<PublicBookType | CatalogBookType>;
+  total: number;
+  page: number;
+  pageSize: number;
 }
 
 // =============================================================================
@@ -45,7 +53,7 @@ const fetcher = (url: string) =>
 /**
  * Map PublicBookType → BookType-compatible shape for existing components.
  */
-function toCardBook(b: PublicBookType): CatalogBookType {
+function toCardBook(b: PublicBookType | CatalogBookType): CatalogBookType {
   return {
     id: b.id,
     title: b.title ?? "",
@@ -64,16 +72,19 @@ function toCardBook(b: PublicBookType): CatalogBookType {
 
 interface CatalogCardGridProps {
   renderedBooks: BookType[];
-  pageIndex: number;
+  totalBooks: number;
+  maxBooks: number;
   onLoadMore: () => void;
 }
 
 const CatalogCardGrid = memo(function CatalogCardGrid({
   renderedBooks,
-  pageIndex,
+  totalBooks,
+  maxBooks,
   onLoadMore,
 }: CatalogCardGridProps) {
   const noop = useCallback(() => {}, []);
+  const visibleLimit = Math.min(totalBooks, maxBooks);
 
   return (
     <div>
@@ -81,7 +92,7 @@ const CatalogCardGrid = memo(function CatalogCardGrid({
         className="grid gap-3 justify-items-center py-2"
         style={{ gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))" }}
       >
-        {renderedBooks.slice(0, pageIndex).map((b: BookType) => (
+        {renderedBooks.map((b: BookType) => (
           <BookSummaryCard
             key={b.id}
             book={b}
@@ -91,13 +102,13 @@ const CatalogCardGrid = memo(function CatalogCardGrid({
           />
         ))}
       </div>
-      {renderedBooks.length - pageIndex > 0 && (
+      {visibleLimit - renderedBooks.length > 0 && (
         <div className="flex justify-center mt-4">
           <button
             onClick={onLoadMore}
             className="px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors"
           >
-            Weitere Bücher… {Math.max(0, renderedBooks.length - pageIndex)}
+            Weitere Bücher… {Math.max(0, visibleLimit - renderedBooks.length)}
           </button>
         </div>
       )}
@@ -111,42 +122,62 @@ const CatalogCardGrid = memo(function CatalogCardGrid({
 
 export default function Catalog({
   books: initialBooks,
+  total: initialTotal,
   numberBooksToShow,
   maxBooks,
+  initialSearch,
 }: CatalogPropsType) {
-  const { data: freshData } = useSWR("/api/public/books", fetcher, {
-    fallbackData: initialBooks,
+  const [bookSearchInput, setBookSearchInput] = useState(initialSearch);
+  const [serverSearch, setServerSearch] = useState(initialSearch);
+  const [pageSize, setPageSize] = useState(numberBooksToShow);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setServerSearch(bookSearchInput);
+      setPageSize(numberBooksToShow);
+    }, 150);
+
+    return () => clearTimeout(id);
+  }, [bookSearchInput, numberBooksToShow]);
+
+  const requestUrl = useMemo(() => {
+    const params = new URLSearchParams({
+      page: "1",
+      pageSize: Math.min(pageSize, maxBooks).toString(),
+    });
+    if (serverSearch.trim()) params.set("q", serverSearch.trim());
+    return `/api/public/books?${params.toString()}`;
+  }, [pageSize, maxBooks, serverSearch]);
+
+  const { data } = useSWR<PagedCatalogResponse>(requestUrl, fetcher, {
+    fallbackData: {
+      books: initialBooks,
+      total: initialTotal,
+      page: 1,
+      pageSize: numberBooksToShow,
+    },
     refreshInterval: 0,
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     dedupingInterval: 60000,
   });
 
-  const rawBooks: PublicBookType[] = Array.isArray(freshData)
-    ? freshData
-    : initialBooks;
-
-  const books = useMemo(() => rawBooks.map(toCardBook), [rawBooks]);
-
-  const [pageIndex, setPageIndex] = useState(numberBooksToShow);
-
-  const { renderedBooks, bookSearchInput, handleInputChange, resultCount } =
-    useBookSearch(books, {
-      extraSearchableFields: ["searchableTopics"],
-      perPage: maxBooks,
-    });
+  const books = useMemo(
+    () => (data?.books ?? initialBooks).map(toCardBook),
+    [data?.books, initialBooks],
+  );
+  const resultCount = data?.total ?? initialTotal;
 
   const handleInputChangeEvent = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-      handleInputChange(e.target.value);
-      setPageIndex(numberBooksToShow);
+      setBookSearchInput(e.target.value);
     },
-    [handleInputChange, numberBooksToShow],
+    [],
   );
 
   const handleLoadMore = useCallback(() => {
-    setPageIndex((prev) => prev + numberBooksToShow);
-  }, [numberBooksToShow]);
+    setPageSize((prev) => Math.min(prev + numberBooksToShow, maxBooks));
+  }, [numberBooksToShow, maxBooks]);
 
   const noop = useCallback(() => {}, []);
 
@@ -163,8 +194,9 @@ export default function Catalog({
         showViewToggle={false}
       />
       <CatalogCardGrid
-        renderedBooks={renderedBooks}
-        pageIndex={pageIndex}
+        renderedBooks={books}
+        totalBooks={resultCount}
+        maxBooks={maxBooks}
         onLoadMore={handleLoadMore}
       />
     </Layout>
@@ -176,7 +208,7 @@ export default function Catalog({
 // =============================================================================
 
 export const getServerSideProps: GetServerSideProps = async (
-  _context: GetServerSidePropsContext,
+  context: GetServerSidePropsContext,
 ) => {
   const numberBooksToShow = process.env.NUMBER_BOOKS_OVERVIEW
     ? parseInt(process.env.NUMBER_BOOKS_OVERVIEW)
@@ -184,13 +216,27 @@ export const getServerSideProps: GetServerSideProps = async (
   const maxBooks = process.env.NUMBER_BOOKS_MAX
     ? parseInt(process.env.NUMBER_BOOKS_MAX)
     : 1000000;
+  const initialSearch =
+    typeof context.query.q === "string" ? context.query.q : "";
 
   try {
-    // Calls the same entity function the API route uses, in-process —
-    // no self-HTTP round trip, no double JSON (de)serialization.
-    const rawBooks = await getPublicBooks(prisma);
-    const books = rawBooks.map(toCardBook);
-    return { props: { books, numberBooksToShow, maxBooks } };
+    // Calls the same entity function the API route uses, in-process:
+    // no self-HTTP round trip, no double JSON serialization.
+    const data = await getPagedPublicBooks(prisma, {
+      page: 1,
+      pageSize: numberBooksToShow,
+      query: initialSearch,
+    });
+    const books = data.books.map(toCardBook);
+    return {
+      props: {
+        books,
+        total: data.total,
+        numberBooksToShow,
+        maxBooks,
+        initialSearch,
+      },
+    };
   } catch (error) {
     errorLogger.error(
       {
@@ -200,6 +246,14 @@ export const getServerSideProps: GetServerSideProps = async (
       },
       "Error fetching public catalog",
     );
-    return { props: { books: [], numberBooksToShow, maxBooks } };
+    return {
+      props: {
+        books: [],
+        total: 0,
+        numberBooksToShow,
+        maxBooks,
+        initialSearch,
+      },
+    };
   }
 };

--- a/pages/catalog/index.tsx
+++ b/pages/catalog/index.tsx
@@ -156,6 +156,10 @@ export default function Catalog({
       page: 1,
       pageSize: numberBooksToShow,
     },
+    // Without this, every key change (new search term, larger pageSize from
+    // "load more") would fall back to the initial unfiltered page-1 data
+    // while the fetch is in flight — a visible flash of wrong results.
+    keepPreviousData: true,
     refreshInterval: 0,
     revalidateOnFocus: false,
     revalidateOnReconnect: false,


### PR DESCRIPTION
Closes #471.

/book and /catalog no longer download the whole inventory. /api/book and /api/public/books take page, pageSize and q and return one page plus a total count, the pages only fetch what they show, and "load more" simply requests a bigger page. The list endpoint also selects only the fields the views need, and the copies-per-ISBN count now comes from the database. Without a pageSize both APIs return the plain array as before, so existing consumers keep working.

Moving search into SQL changed its behavior in a few ways worth knowing. The old client-side search (itemsjs) ran an English Porter stemmer over German text, which accidentally made queries like "Deutsche" find "Deutsch". I replaced that with a small locale-aware suffix strip on the query terms, so this now works on purpose, and verified against a real database that the sampled queries return the same or more results than before. Umlauts needed extra care because SQLite only case-folds ASCII. Multi-word queries now require every word to match (each in any field), results come newest first instead of relevance-ranked, and a purely numeric query matches the exact book id, including with leading zeros from a barcode scanner.

While in there I fixed updateBook to only detach a user when the rental status is explicitly set to something other than rented, and to run the update, the disconnect and the audit entry in one transaction. The commit messages document the behavior changes in more detail.


The measurements further down the thread show what this is for. With the change the JSON that Next.js ships into the catalogue page stays at roughly 7 KB whether the library holds 500 or 4000 books, and the heap stays flat at 4.8 MB. On main both grow with the inventory, up to 1.3 MB of book data delivered to render twenty cards.

`cypress/e2e/bookpagination.cy.ts` covers the new contract. A page comes back with its slice and the catalogue total, consecutive pages do not overlap, a search term narrows the set on the server, and both `/api/book` and `/api/public/books` still answer with a plain array when no `pageSize` is given. The API reference documents the three parameters and the paged response shape, including the note that `total` counts the whole result set rather than the returned page.

The login image encoding fix that used to sit in this branch is gone from it. It was a real fix but it only touches the login page and had no business here, so it will come as its own small PR. The branch is rebased on current main.
