### PR TITLE
Fix 404 on the public catalog detail page

### DIFF
--- a/entities/publicBook.ts
+++ b/entities/publicBook.ts
@@ -1,0 +1,103 @@
+import { PublicBookDetailType } from "@/entities/PublicBookDetailType";
+import { PublicBookType } from "@/entities/PublicBookType";
+import { PrismaClient } from "@prisma/client";
+
+const RELATED_LIMIT = 5;
+
+function parseTopics(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(";")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Public detail view for a single book, plus a few related books that share
+ * topics. Returns null when the book does not exist.
+ *
+ * Whitelisted `select` only (see PublicBookType) so no PII-adjacent field can
+ * leak. Shared by the API route (/api/public/books/[id]) and the catalog detail
+ * page's getServerSideProps, so the page reads the DB directly instead of making
+ * an HTTP round-trip to its own API (which breaks under HTTPS and is slower).
+ */
+export async function getPublicBookDetail(
+  client: PrismaClient,
+  id: number,
+): Promise<PublicBookDetailType | null> {
+  const book = await client.book.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      author: true,
+      isbn: true,
+      topics: true,
+      rentalStatus: true,
+      subtitle: true,
+      summary: true,
+      publisherName: true,
+      publisherDate: true,
+      pages: true,
+      minAge: true,
+      maxAge: true,
+    },
+  });
+
+  if (!book) return null;
+
+  const topics = parseTopics(book.topics);
+
+  let relatedBooks: PublicBookType[] = [];
+  if (topics.length > 0) {
+    const candidates = await client.book.findMany({
+      where: {
+        id: { not: id },
+        OR: topics.map((topic) => ({ topics: { contains: topic } })),
+      },
+      select: {
+        id: true,
+        title: true,
+        author: true,
+        isbn: true,
+        topics: true,
+        rentalStatus: true,
+      },
+    });
+
+    relatedBooks = candidates
+      .map((b) => ({
+        book: b,
+        shared: parseTopics(b.topics).filter((t) => topics.includes(t)).length,
+      }))
+      .sort((a, b) => b.shared - a.shared)
+      .slice(0, RELATED_LIMIT)
+      .map(({ book: b }) => ({
+        id: b.id,
+        title: b.title,
+        author: b.author,
+        isbn: b.isbn,
+        topics: b.topics,
+        rentalStatus: b.rentalStatus,
+        coverUrl: `/api/images/${b.id}`,
+      }));
+  }
+
+  return {
+    id: book.id,
+    title: book.title,
+    author: book.author,
+    isbn: book.isbn,
+    topics: book.topics,
+    rentalStatus: book.rentalStatus,
+    coverUrl: `/api/images/${book.id}`,
+    subtitle: book.subtitle,
+    summary: book.summary,
+    publisherName: book.publisherName,
+    publisherDate: book.publisherDate,
+    pages: book.pages,
+    minAge: book.minAge,
+    maxAge: book.maxAge,
+    relatedBooks,
+  };
+}

--- a/entities/publicBook.ts
+++ b/entities/publicBook.ts
@@ -3,6 +3,10 @@ import { PublicBookType } from "@/entities/PublicBookType";
 import { PrismaClient } from "@prisma/client";
 
 const RELATED_LIMIT = 5;
+// A ceiling on the rows a single detail view will pull in. A topic like
+// "Roman" can otherwise match most of the library, all of it read into memory
+// to fill five slots on a public page.
+const RELATED_CANDIDATE_LIMIT = 500;
 
 function parseTopics(raw: string | null | undefined): string[] {
   if (!raw) return [];
@@ -63,13 +67,28 @@ export async function getPublicBookDetail(
         topics: true,
         rentalStatus: true,
       },
+      take: RELATED_CANDIDATE_LIMIT,
     });
+
+    // `contains` above matches anywhere in the semicolon-joined string, so
+    // "Kunst" also pulls in everything tagged "Kunstgeschichte". Those score
+    // zero shared topics, and used to be shown anyway whenever there were
+    // fewer than five genuine matches.
+    const isbn = book.isbn?.trim();
+    const titleAuthor = `${book.title ?? ""}|${book.author ?? ""}`.toLowerCase();
+
+    // Another copy of the same book is not a related book.
+    const isSameBook = (b: (typeof candidates)[number]) =>
+      isbn
+        ? b.isbn?.trim() === isbn
+        : `${b.title ?? ""}|${b.author ?? ""}`.toLowerCase() === titleAuthor;
 
     relatedBooks = candidates
       .map((b) => ({
         book: b,
         shared: parseTopics(b.topics).filter((t) => topics.includes(t)).length,
       }))
+      .filter(({ book: b, shared }) => shared > 0 && !isSameBook(b))
       .sort((a, b) => b.shared - a.shared)
       .slice(0, RELATED_LIMIT)
       .map(({ book: b }) => ({

--- a/entities/publicBook.ts
+++ b/entities/publicBook.ts
@@ -3,6 +3,31 @@ import { PublicBookType } from "@/entities/PublicBookType";
 import { PrismaClient } from "@prisma/client";
 
 const RELATED_LIMIT = 5;
+
+/**
+ * Matches one whole topic inside the ";"-separated topics column.
+ *
+ * A plain `contains` matches anywhere in the joined string, so "Kunst" also
+ * hits everything tagged "Kunstgeschichte". Those carry no shared topic and
+ * were dropped afterwards, but they were fetched first, and with the row cap
+ * below they could crowd genuine matches out of the query entirely. Anchoring
+ * on the separators means the rows that come back are the ones that count.
+ * Both separator spellings are listed because counting trims each entry, so
+ * "Abenteuer; Freundschaft" advertises Freundschaft.
+ */
+function topicMatch(topic: string) {
+  const separators = [";", "; "];
+  const variants: Array<Record<string, unknown>> = [{ topics: topic }];
+  for (const sep of separators) {
+    variants.push(
+      { topics: { startsWith: `${topic};` } },
+      { topics: { endsWith: `${sep}${topic}` } },
+      { topics: { contains: `${sep}${topic};` } },
+      { topics: { contains: `${sep}${topic}; ` } },
+    );
+  }
+  return { OR: variants };
+}
 // A ceiling on the rows a single detail view will pull in. A topic like
 // "Roman" can otherwise match most of the library, all of it read into memory
 // to fill five slots on a public page.
@@ -57,7 +82,7 @@ export async function getPublicBookDetail(
     const candidates = await client.book.findMany({
       where: {
         id: { not: id },
-        OR: topics.map((topic) => ({ topics: { contains: topic } })),
+        OR: topics.map(topicMatch),
       },
       select: {
         id: true,
@@ -70,10 +95,6 @@ export async function getPublicBookDetail(
       take: RELATED_CANDIDATE_LIMIT,
     });
 
-    // `contains` above matches anywhere in the semicolon-joined string, so
-    // "Kunst" also pulls in everything tagged "Kunstgeschichte". Those score
-    // zero shared topics, and used to be shown anyway whenever there were
-    // fewer than five genuine matches.
     const isbn = book.isbn?.trim();
     const titleAuthor = `${book.title ?? ""}|${book.author ?? ""}`.toLowerCase();
 
@@ -83,12 +104,31 @@ export async function getPublicBookDetail(
         ? b.isbn?.trim() === isbn
         : `${b.title ?? ""}|${b.author ?? ""}`.toLowerCase() === titleAuthor;
 
-    relatedBooks = candidates
-      .map((b) => ({
-        book: b,
-        shared: parseTopics(b.topics).filter((t) => topics.includes(t)).length,
-      }))
-      .filter(({ book: b, shared }) => shared > 0 && !isSameBook(b))
+    // One entry per title. Copies of another book share its ISBN and all its
+    // topics, so five copies of one title could take all five slots and the
+    // list read as a single recommendation repeated.
+    const bestPerTitle = new Map<
+      string,
+      { book: (typeof candidates)[number]; shared: number }
+    >();
+    for (const b of candidates) {
+      if (isSameBook(b)) continue;
+      const shared = parseTopics(b.topics).filter((t) =>
+        topics.includes(t),
+      ).length;
+      if (shared === 0) continue;
+      const key = b.isbn?.trim()
+        ? `i:${b.isbn.trim()}`
+        : `t:${(b.title ?? "").trim().toLowerCase()}|${(b.author ?? "")
+            .trim()
+            .toLowerCase()}`;
+      const existing = bestPerTitle.get(key);
+      if (!existing || shared > existing.shared) {
+        bestPerTitle.set(key, { book: b, shared });
+      }
+    }
+
+    relatedBooks = [...bestPerTitle.values()]
       .sort((a, b) => b.shared - a.shared)
       .slice(0, RELATED_LIMIT)
       .map(({ book: b }) => ({

--- a/pages/api/public/books/[id].ts
+++ b/pages/api/public/books/[id].ts
@@ -1,16 +1,9 @@
 import { PublicBookDetailType } from "@/entities/PublicBookDetailType";
-import { PublicBookType } from "@/entities/PublicBookType";
 import { prisma, reconnectPrisma } from "@/entities/db";
+import { getPublicBookDetail } from "@/entities/publicBook";
 import { LogEvents } from "@/lib/logEvents";
 import { errorLogger } from "@/lib/logger";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-const RELATED_LIMIT = 5;
-
-function parseTopics(raw: string | null | undefined): string[] {
-  if (!raw) return [];
-  return raw.split(";").map((t) => t.trim()).filter(Boolean);
-}
 
 export default async function handler(
   req: NextApiRequest,
@@ -33,84 +26,10 @@ export default async function handler(
   res.setHeader("Cache-Control", "public, max-age=60, s-maxage=300");
 
   try {
-    const book = await prisma.book.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        title: true,
-        author: true,
-        isbn: true,
-        topics: true,
-        rentalStatus: true,
-        subtitle: true,
-        summary: true,
-        publisherName: true,
-        publisherDate: true,
-        pages: true,
-        minAge: true,
-        maxAge: true,
-      },
-    });
-
-    if (!book) {
+    const detail = await getPublicBookDetail(prisma, id);
+    if (!detail) {
       return res.status(404).json({ result: "Book not found" });
     }
-
-    const topics = parseTopics(book.topics);
-
-    let relatedBooks: PublicBookType[] = [];
-    if (topics.length > 0) {
-      const candidates = await prisma.book.findMany({
-        where: {
-          id: { not: id },
-          OR: topics.map((topic) => ({ topics: { contains: topic } })),
-        },
-        select: {
-          id: true,
-          title: true,
-          author: true,
-          isbn: true,
-          topics: true,
-          rentalStatus: true,
-        },
-      });
-
-      relatedBooks = candidates
-        .map((b) => ({
-          book: b,
-          shared: parseTopics(b.topics).filter((t) => topics.includes(t)).length,
-        }))
-        .sort((a, b) => b.shared - a.shared)
-        .slice(0, RELATED_LIMIT)
-        .map(({ book: b }) => ({
-          id: b.id,
-          title: b.title,
-          author: b.author,
-          isbn: b.isbn,
-          topics: b.topics,
-          rentalStatus: b.rentalStatus,
-          coverUrl: `/api/images/${b.id}`,
-        }));
-    }
-
-    const detail: PublicBookDetailType = {
-      id: book.id,
-      title: book.title,
-      author: book.author,
-      isbn: book.isbn,
-      topics: book.topics,
-      rentalStatus: book.rentalStatus,
-      coverUrl: `/api/images/${book.id}`,
-      subtitle: book.subtitle,
-      summary: book.summary,
-      publisherName: book.publisherName,
-      publisherDate: book.publisherDate,
-      pages: book.pages,
-      minAge: book.minAge,
-      maxAge: book.maxAge,
-      relatedBooks,
-    };
-
     return res.status(200).json(detail);
   } catch (error) {
     errorLogger.error(

--- a/pages/catalog/[id].tsx
+++ b/pages/catalog/[id].tsx
@@ -3,6 +3,10 @@ import Layout from "@/components/layout/Layout";
 import { BookType } from "@/entities/BookType";
 import { PublicBookDetailType } from "@/entities/PublicBookDetailType";
 import { PublicBookType } from "@/entities/PublicBookType";
+import { prisma } from "@/entities/db";
+import { getPublicBookDetail } from "@/entities/publicBook";
+import { LogEvents } from "@/lib/logEvents";
+import { errorLogger } from "@/lib/logger";
 import { translations } from "@/entities/fieldTranslations";
 import { t } from "@/lib/i18n";
 import { ArrowLeft, BookOpen, Calendar, Hash, Tag, Users } from "lucide-react";
@@ -332,22 +336,31 @@ export default function CatalogDetailPage({ book }: CatalogDetailProps) {
 export const getServerSideProps: GetServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
-  const host = context.req.headers.host ?? "localhost:3000";
-  const baseUrl = `http://${host}`;
-
-  const id = context.params?.id as string;
+  const id = parseInt(context.params?.id as string, 10);
+  if (Number.isNaN(id)) {
+    return { notFound: true };
+  }
 
   try {
-    const res = await fetch(`${baseUrl}/api/public/books/${id}`);
-
-    if (!res.ok) {
+    // Read the DB directly rather than fetching our own API over HTTP: the
+    // self-fetch broke under HTTPS (an http:// request against an https:// port)
+    // and is a needless round-trip. getPublicBookDetail applies the same public
+    // field whitelist the API uses.
+    const book = await getPublicBookDetail(prisma, id);
+    if (!book) {
       return { notFound: true };
     }
-
-    const book: PublicBookDetailType = await res.json();
     return { props: { book } };
   } catch (error) {
-    console.error("Error fetching catalog book detail:", error);
+    errorLogger.error(
+      {
+        event: LogEvents.API_ERROR,
+        endpoint: "/catalog/[id] (getServerSideProps)",
+        bookId: id,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Error fetching catalog book detail",
+    );
     return { notFound: true };
   }
 };


### PR DESCRIPTION
Fixes #495.

`getServerSideProps` in `pages/catalog/[id].tsx` fetched its own API over HTTP:

```ts
const host = context.req.headers.host ?? "localhost:3000";
const baseUrl = `http://${host}`;
const res = await fetch(`${baseUrl}/api/public/books/${id}`);
```

The host comes from the request, but the scheme is hardcoded to `http`. On an HTTPS deployment the server therefore sends a plaintext request to its own TLS port. Since any failure of that request returns `notFound`, the detail page renders as a 404 while the catalog list works fine.

I can reproduce this on a Raspberry Pi behind a reverse proxy with TLS on a non-default port, where the self-request gets a 400 back. In #495 the same call fails with `ECONNREFUSED` because the container cannot reach itself. Different trigger, same mechanism, and it is not Windows specific.

## What this changes

The query moves into `getPublicBookDetail()` in `entities/publicBook.ts`, and both the API route and the page call it. The API route keeps working exactly as before and is still the public interface for external clients. The point is that the public field whitelist now lives in one place, so the page and the API cannot drift apart.

This also brings the page in line with the rest of the codebase. Every other page with `getServerSideProps` already reads the database through the prisma singleton, and `pages/catalog/index.tsx` in particular already does exactly this, with the comment "Calls the same entity function the API route uses, in-process, no self-HTTP round trip, no double JSON (de)serialization". The detail page was the only one still going out over HTTP.

Errors now go through `errorLogger` with `LogEvents.API_ERROR` instead of `console.error`, matching the catalog list page.

## Notes

The auth part of this is already fixed on main. `/catalog/<id>` used to be behind the login wall because `proxy.ts` allowlisted only the exact path `/catalog`, which is why the detail page redirected to the sign-in form in 1.10.1. That allowlist entry landed separately, so this PR only contains the data fetching change.

## Verified

Unauthenticated `/catalog/<id>` returns 200 and renders the book, a nonexistent id still returns 404, and `/api/public/books/<id>` still returns the same JSON as before. Also running in production on the HTTPS deployment described above, where the page returned a 404 before this change.
