### PR TITLE
Make the route behind / configurable

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -9,6 +9,10 @@ DATABASE_URL="file:./database/dev.db"
 OPENLIBRY_LOCALE=de
 NEXT_PUBLIC_OPENLIBRY_LOCALE=de
 
+# Route opened from /. Defaults to /manage, the internal landing page.
+# Set it to /catalog to make the public catalog the front page of your library.
+OPENLIBRY_ROOT_ROUTE=/manage
+
 
 # 🔐 Authentication: URLs for NextAuth (used for callbacks and redirects)
 NEXTAUTH_URL=http://localhost:3000

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,7 +1,11 @@
 import { t } from "@/lib/i18n";
 import { useEffect, useState } from "react";
 
-export default function Footer() {
+interface FooterProps {
+  publicView?: boolean;
+}
+
+export default function Footer({ publicView = false }: FooterProps) {
   const [currentVersion, setCurrentVersion] = useState<string>("");
 
   useEffect(() => {
@@ -16,9 +20,17 @@ export default function Footer() {
   return (
     <footer className="text-center pt-12 pb-6">
       <div className="flex flex-col md:flex-row items-center justify-center gap-4 md:gap-6 text-sm">
-        <a href="./catalog" className="text-inherit hover:underline">
-          {t("footer.publicCatalog")}
-        </a>
+        {publicView ? (
+          // Public pages link to the internal area; internal pages link to
+          // the public catalog. Each side points at the other.
+          <a href="/manage" className="text-inherit hover:underline">
+            {t("footer.manage")}
+          </a>
+        ) : (
+          <a href="./catalog" className="text-inherit hover:underline">
+            {t("footer.publicCatalog")}
+          </a>
+        )}
         <a href="https://openlibry.de" className="text-inherit hover:underline">
           {t("footer.copyright")}
         </a>

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({
     <div>
       {!publicView && <TopBar showAdminButton={showAdminButton} />}
       <div className="max-w-5xl mx-auto px-4 md:px-6">{children}</div>
-      <Footer />
+      <Footer publicView={publicView} />
     </div>
   );
 }

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -70,7 +70,7 @@ export default function TopBar({ showAdminButton = true }: TopBarProps) {
             {/* Logo & Brand - Desktop */}
             <div
               className="hidden md:flex items-center gap-3 cursor-pointer mr-8 group"
-              onClick={() => router.push("/")}
+              onClick={() => router.push("/manage")}
             >
               <div className="flex items-center justify-center w-[42px] h-[42px] rounded-lg text-white bg-white/15 border border-white/20 transition-transform duration-300 group-hover:-rotate-[10deg] group-hover:scale-110">
                 <ReaderIcon
@@ -100,7 +100,7 @@ export default function TopBar({ showAdminButton = true }: TopBarProps) {
             {/* Logo & Brand - Mobile */}
             <div
               className="flex md:hidden items-center gap-2 flex-grow cursor-pointer text-white"
-              onClick={() => router.push("/")}
+              onClick={() => router.push("/manage")}
             >
               <ReaderIcon width={24} height={24} data-cy="topbar_logo_mobile" />
               <span

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -155,6 +155,23 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       loadServerEnv(config);
 
+      // rootroute-public.cy.ts asserts that / serves the public catalog, which
+      // only holds when the server was started with OPENLIBRY_ROOT_ROUTE
+      // pointing there. That is read server-side and cannot be flipped from a
+      // spec, so in a normal run the spec cannot pass and its failure says
+      // nothing about the code. `npm run test:e2e:publicroot` starts such a
+      // server, and only there does the spec take part.
+      if (process.env.OPENLIBRY_ROOT_ROUTE !== "/catalog") {
+        config.excludeSpecPattern = [
+          ...(Array.isArray(config.excludeSpecPattern)
+            ? config.excludeSpecPattern
+            : config.excludeSpecPattern
+              ? [config.excludeSpecPattern]
+              : []),
+          "**/rootroute-public.cy.ts",
+        ];
+      }
+
       // Load fixtures once at startup so they're available inside every task
       // without re-reading from disk on each call.
       const loginUserFixtures = loadFixtures<FixtureLoginUser>(

--- a/cypress/e2e/rootroute-public.cy.ts
+++ b/cypress/e2e/rootroute-public.cy.ts
@@ -1,0 +1,44 @@
+/// <reference types="cypress" />
+
+// Runs only against a server started with OPENLIBRY_ROOT_ROUTE=/catalog:
+//
+//   npm run test:e2e:publicroot
+//
+// This is the other half of the middleware check in proxy.ts, which exempts /
+// from authentication only when the configured target is itself public. The
+// env var is read server-side, so it cannot be flipped from inside a spec and
+// this case needs its own server rather than living in rootroute.cy.ts.
+
+describe("Root route pointed at the public catalog", () => {
+  before(() => {
+    cy.resetAndSeed();
+  });
+
+  after(() => {
+    cy.clearDatabase();
+  });
+
+  beforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+
+  it("should serve the catalog at / without authentication", () => {
+    cy.visit("/");
+
+    cy.url().should("include", "/catalog");
+    cy.url().should("not.include", "/auth/login");
+    // Generous timeout: this is usually the first page the dev server has to
+    // compile in this run, and the default 4s can expire before it responds.
+    cy.get("[data-cy^=book_summary_card_]", { timeout: 20000 }).should(
+      "have.length.greaterThan",
+      0,
+    );
+  });
+
+  it("should still gate the internal landing page", () => {
+    cy.visit("/manage");
+
+    cy.url().should("include", "/auth/login");
+  });
+});

--- a/cypress/e2e/rootroute.cy.ts
+++ b/cypress/e2e/rootroute.cy.ts
@@ -1,0 +1,41 @@
+/// <reference types="cypress" />
+
+// Covers the default configuration, where OPENLIBRY_ROOT_ROUTE is unset and /
+// therefore redirects to the internal landing page at /manage. If your
+// .env.test.local sets OPENLIBRY_ROOT_ROUTE these will fail; the public-catalog
+// configuration has its own spec in rootroute-public.cy.ts, which needs a
+// separately configured server (npm run test:e2e:publicroot).
+
+describe("Root route redirect", () => {
+  before(() => {
+    cy.resetAndSeed();
+  });
+
+  after(() => {
+    cy.clearDatabase();
+  });
+
+  it("should bounce an unauthenticated visitor from / to the login page", () => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+    cy.visit("/");
+
+    cy.url().should("include", "/auth/login");
+    cy.url().should("not.include", "/catalog");
+    cy.get('input[id="user"]').should("be.visible");
+  });
+
+  it("should return to the landing page after logging in from /", () => {
+    cy.login();
+
+    cy.url().should("include", "/manage");
+  });
+
+  it("should send an authenticated visitor from / to /manage", () => {
+    cy.login();
+    cy.visit("/");
+
+    cy.url().should("include", "/manage");
+    cy.get("[data-cy=indexpage]").should("be.visible");
+  });
+});

--- a/lib/i18n/de.ts
+++ b/lib/i18n/de.ts
@@ -1262,6 +1262,9 @@ export const de = {
     //   Datenschutz → "Privacy"
     imprint: "Impressum",
     privacy: "Datenschutz",
+    // Shown instead of publicCatalog on public pages: entry point to the
+    // internal area.
+    manage: "Verwalten",
   },
 
   // ─── ISBN lookup API error messages ──────────────────────────────────

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -1167,6 +1167,7 @@ export const en: Dictionary = {
     copyright: "Copyright",
     imprint: "Legal notice",
     privacy: "Privacy",
+    manage: "Manage",
   },
 
   // ─── ISBN lookup API error messages ──────────────────────────────────

--- a/lib/i18n/es.ts
+++ b/lib/i18n/es.ts
@@ -1183,13 +1183,13 @@ export const es: Dictionary = {
     fieldIsbn: "ISBN",
     notFound: "Libro no encontrado.",
   },
-
   // ─── Phase 11f: site footer ───────────────────────────────────────────
   footer: {
     publicCatalog: "Catálogo público",
     copyright: "Copyright",
     imprint: "Aviso legal",
     privacy: "Privacidad",
+    manage: "Gestionar",
   },
 
   // ─── ISBN lookup API error messages ──────────────────────────────────

--- a/lib/i18n/es.ts
+++ b/lib/i18n/es.ts
@@ -1183,6 +1183,7 @@ export const es: Dictionary = {
     fieldIsbn: "ISBN",
     notFound: "Libro no encontrado.",
   },
+
   // ─── Phase 11f: site footer ───────────────────────────────────────────
   footer: {
     publicCatalog: "Catálogo público",

--- a/lib/rootRoute.ts
+++ b/lib/rootRoute.ts
@@ -1,0 +1,26 @@
+const DEFAULT_ROOT_ROUTE = "/manage";
+
+export function getConfiguredRootRoute(): string {
+  const configured = process.env.OPENLIBRY_ROOT_ROUTE?.trim();
+  if (
+    !configured ||
+    configured === "/" ||
+    !configured.startsWith("/") ||
+    configured.startsWith("//") ||
+    configured.includes("\\")
+  ) {
+    return DEFAULT_ROOT_ROUTE;
+  }
+
+  return configured;
+}
+
+export function isPublicRoutePath(pathname: string): boolean {
+  return (
+    pathname === "/catalog" ||
+    pathname.startsWith("/catalog/") ||
+    pathname === "/api/version" ||
+    pathname.startsWith("/api/public/") ||
+    pathname.startsWith("/api/images")
+  );
+}

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "start": "next start",
     "lint": "next lint",
     "dev:test": "next dev",
+    "dev:test:publicroot": "OPENLIBRY_ROOT_ROUTE=/catalog next dev",
     "cypress": "cypress open",
     "cypress:headless": "cypress run",
     "test:e2e": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test 'dev:test' http-get://localhost:3000 cypress:headless",
-    "test:e2e:ui": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test dev http-get://localhost:3000 cypress"
+    "test:e2e:ui": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test dev http-get://localhost:3000 cypress",
+    "test:e2e:publicroot": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test 'dev:test:publicroot' http-get://localhost:3000 'cypress run --spec cypress/e2e/rootroute-public.cy.ts'"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cypress:headless": "cypress run",
     "test:e2e": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test 'dev:test' http-get://localhost:3000 cypress:headless",
     "test:e2e:ui": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test dev http-get://localhost:3000 cypress",
-    "test:e2e:publicroot": "NODE_ENV=test dotenv -e .env.test.local start-server-and-test 'dev:test:publicroot' http-get://localhost:3000 'cypress run --spec cypress/e2e/rootroute-public.cy.ts'"
+    "test:e2e:publicroot": "NODE_ENV=test OPENLIBRY_ROOT_ROUTE=/catalog dotenv -e .env.test.local start-server-and-test 'dev:test:publicroot' http-get://localhost:3000 'cypress run --spec cypress/e2e/rootroute-public.cy.ts'"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,78 +1,14 @@
-import Layout from "@/components/layout/Layout";
-import { publicNavItems } from "@/components/layout/NavigationItems";
-import NavTile from "@/components/title/NavTile";
-import { t } from "@/lib/i18n";
-import { useRouter } from "next/router";
+import { getConfiguredRootRoute } from "@/lib/rootRoute";
 
-interface HomeProps {
-  showAdminButton: boolean;
-}
-
-export default function Home({ showAdminButton }: HomeProps) {
-  const router = useRouter();
-
-  const handleNavigation = (slug: string) => {
-    router.push(slug);
-  };
-
-  return (
-    <div data-cy="indexpage" className="relative min-h-screen">
-      {/* Background image layer */}
-      <div
-        className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundImage: "url('/splashbanner.jpg')" }}
-      />
-      {/* Gradient overlay */}
-      <div className="absolute inset-0 bg-gradient-to-br from-primary-light/10 via-primary/5 to-background" />
-
-      {/* Content */}
-      <div className="relative">
-        <Layout showAdminButton={showAdminButton}>
-          <div className="max-w-5xl mx-auto px-4 ">
-            <div className="flex flex-col items-center gap-15 pt-40 md:pt-48 pb-8 md:pb-16">
-              {/* Navigation Tiles */}
-              <div
-                className="
-                grid gap-4 mt-4 w-fit mx-auto
-                grid-cols-1 sm:grid-cols-2 md:grid-cols-4 
-              "
-              >
-                {publicNavItems.map((item) => (
-                  <NavTile
-                    key={item.slug}
-                    title={item.title}
-                    subtitle={item.subtitle}
-                    slug={item.slug}
-                    icon={item.icon}
-                    onClick={() => handleNavigation(item.slug)}
-                  />
-                ))}
-              </div>
-
-              {/* Footer hint */}
-              <p className="text-xs text-muted-foreground/60 mt-4 text-center">
-                {t("home.chooseSection")}
-              </p>
-            </div>
-          </div>
-        </Layout>
-      </div>
-    </div>
-  );
+export default function RootRedirect() {
+  return null;
 }
 
 export async function getServerSideProps() {
-  const showAdminButton =
-    parseInt(
-      process.env.BACKUP_BUTTON_SWITCH ||
-        process.env.ADMIN_BUTTON_SWITCH ||
-        "1",
-      10,
-    ) === 1; //keep backup button env for backwards compatibility
-
   return {
-    props: {
-      showAdminButton,
+    redirect: {
+      destination: getConfiguredRootRoute(),
+      permanent: false,
     },
   };
 }

--- a/pages/manage.tsx
+++ b/pages/manage.tsx
@@ -1,0 +1,73 @@
+import Layout from "@/components/layout/Layout";
+import { publicNavItems } from "@/components/layout/NavigationItems";
+import NavTile from "@/components/title/NavTile";
+import { t } from "@/lib/i18n";
+import { useRouter } from "next/router";
+
+interface ManageProps {
+  showAdminButton: boolean;
+}
+
+export default function Manage({ showAdminButton }: ManageProps) {
+  const router = useRouter();
+
+  const handleNavigation = (slug: string) => {
+    router.push(slug);
+  };
+
+  return (
+    <div data-cy="indexpage" className="relative min-h-screen">
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: "url('/splashbanner.jpg')" }}
+      />
+      <div className="absolute inset-0 bg-gradient-to-br from-primary-light/10 via-primary/5 to-background" />
+
+      <div className="relative">
+        <Layout showAdminButton={showAdminButton}>
+          <div className="max-w-5xl mx-auto px-4 ">
+            <div className="flex flex-col items-center gap-15 pt-40 md:pt-48 pb-8 md:pb-16">
+              <div
+                className="
+                grid gap-4 mt-4 w-fit mx-auto
+                grid-cols-1 sm:grid-cols-2 md:grid-cols-4
+              "
+              >
+                {publicNavItems.map((item) => (
+                  <NavTile
+                    key={item.slug}
+                    title={item.title}
+                    subtitle={item.subtitle}
+                    slug={item.slug}
+                    icon={item.icon}
+                    onClick={() => handleNavigation(item.slug)}
+                  />
+                ))}
+              </div>
+
+              <p className="text-xs text-muted-foreground/60 mt-4 text-center">
+                {t("home.chooseSection")}
+              </p>
+            </div>
+          </div>
+        </Layout>
+      </div>
+    </div>
+  );
+}
+
+export async function getServerSideProps() {
+  const showAdminButton =
+    parseInt(
+      process.env.BACKUP_BUTTON_SWITCH ||
+        process.env.ADMIN_BUTTON_SWITCH ||
+        "1",
+      10,
+    ) === 1;
+
+  return {
+    props: {
+      showAdminButton,
+    },
+  };
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,4 +1,5 @@
 import { resolveLoginImage } from "@/lib/loginImage";
+import { getConfiguredRootRoute, isPublicRoutePath } from "@/lib/rootRoute";
 import { withAuth } from "next-auth/middleware";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -45,13 +46,12 @@ export default withAuth(
         // The configured login background lives in /public and must load on the
         // (unauthenticated) login page, so allow exactly that one file.
         const loginImage = resolveLoginImage();
+        const isPublicRootRedirect =
+          pathname === "/" && isPublicRoutePath(getConfiguredRootRoute());
         const isPublicRoute =
+          isPublicRootRedirect ||
           pathname === "/publicbookview" ||
-          pathname === "/catalog" ||
-          pathname.startsWith("/catalog/") ||
-          pathname.startsWith("/api/images") ||
-          pathname === "/api/version" ||
-          pathname.startsWith("/api/public/") ||
+          isPublicRoutePath(pathname) ||
           (loginImage !== null && pathname === loginImage);
 
         if (isPublicRoute) return true;


### PR DESCRIPTION
Towards #462.

Makes the route behind `/` configurable. `OPENLIBRY_ROOT_ROUTE` defaults to `/manage`, so nothing changes for an existing installation: someone opening the site still lands on the internal landing page and still has to log in. Set it to `/catalog` and the public catalog becomes the front page of the library, which is the option discussed in the issue.

The dashboard that used to live in `pages/index.tsx` moved to `pages/manage.tsx` and `/` is now only a redirect. `proxy.ts` treats `/` as public exactly when the configured root is itself a public path, so with the default nothing is exposed that was not exposed before. The footer now links each side to the other: the public catalog offers a way into the internal area, and the internal pages keep their link to the catalog. That covers the missing entry point mentioned in the issue.

Two things this deliberately does not do, so it is clear what is still open.

It does not let you keep the catalog private. You asked for that in your last comment, and this branch predates it. `/catalog`, `/api/public/` and `/api/images` are still unconditionally public, exactly as they are on main today. The good news is that the check now sits in one place, `isPublicRoutePath` in `lib/rootRoute.ts`, so adding a switch that closes the catalog entirely, or moves it to an unguessable path for a QR code, is a small follow-up rather than another rewrite. I am happy to do that next if you want it in the same release.

It also does not fix the `callbackUrl` handling I mentioned in the issue. A staff member who gets bounced from `/rental` still lands on the landing page after logging in rather than back at `/rental`. Separate concern, separate change.

Testing: `cypress/e2e/rootroute.cy.ts` covers the default, that an anonymous visitor is sent to the login form, that an authenticated one reaches `/manage`, and that logging in from `/` returns to the landing page. `cypress/e2e/rootroute-public.cy.ts` covers the catalog configuration, that `/` serves the catalog without authentication and that `/manage` stays gated. The second one only makes sense against a server started with the flag set, which cannot be done from inside a spec, so `cypress.config.ts` excludes it from a normal run and `npm run test:e2e:publicroot` starts the right server and runs it. Both pass.
